### PR TITLE
ci: trigger on push on main

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -2,7 +2,7 @@ version = 1
 
 [merge.message]
 title = "pull_request_title"
-body = "pull_request_body"
+body = "empty"
 
 [merge.automerge_dependencies]
 versions = ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches: ["main"]
 
 jobs:
   check:


### PR DESCRIPTION
This improves caching as workflows cannot access to cache created by siblings branches. Without this, no cache will be using in first runs in each pull request.

> A workflow can access and restore a cache created in the current branch, the base branch (including base branches of forked repositories), or the default branch (usually main).