### PR TITLE
deps: bump remoc to 0.9.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,13 +385,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 0.4.8",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -647,9 +674,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -665,9 +692,9 @@ checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
@@ -793,18 +820,18 @@ dependencies = [
 
 [[package]]
 name = "remoc"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb3b8b854a45de143806a8323b4c5b97c55b77e9939cb2e3970d3c1ad4c735e"
+checksum = "e2ba3477399a34f7e3590e5cc27ffd8a3d58e3cf82c17e0bd546d9a675089372"
 dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
+ "ciborium",
  "futures",
  "rand",
  "remoc_macro",
  "serde",
- "serde_cbor",
  "tokio",
  "tokio-util",
  "tracing",
@@ -813,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "remoc_macro"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a0e4515f5f058c58e6dd6970eaadd797f98eb429ec20625cd353306aca9e27"
+checksum = "f078576e52c377abeb1cb25b721028c9e96645f89d94ec35dda8c1a8f7476a72"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -939,16 +966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -11,7 +11,7 @@ raidprotect_util = { path = "../util" }
 workspace-hack = { path = "../workspace-hack"}
 
 anyhow = "1"
-remoc = { version = "0.9", features = ["serde", "rch", "rtc", "default-codec-cbor"], default-features = false }
+remoc = { version = "0.9.10", features = ["serde", "rch", "rtc", "default-codec-ciborium"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.14", features = ["macros", "net", "sync"] }
 tracing = { version = "0.1" }


### PR DESCRIPTION
This PR bumps `remoc` to version 0.9.10 and replace CBOR encoding with `ciborium` (see https://github.com/ENQT-GmbH/remoc/pull/3). Other transitive dependencies are also bumped to their latest version.