### PR TITLE
ci: setup gitpod prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,6 +11,12 @@ ports:
     visibility: private
     onOpen: notify
 
+github:
+  prebuilds:
+    master: true
+    pullRequests: true
+    addCheck: true
+
 vscode:
   extensions:
     - editorconfig.editorconfig


### PR DESCRIPTION
GitPod Rust environment is fixed (see PR below), this improves the setup tasks to enable prebuilds.

- https://github.com/gitpod-io/workspace-images/pull/587