### PR TITLE
chore: setup cargo deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,16 +77,16 @@ jobs:
       - name: Setup Rust toolchain
         uses: hecrj/setup-rust-action@v1
 
-      - name: Install cargo-audit
+      - name: Install cargo-deny
         uses: baptiste0928/cargo-install@v1
         with:
-          crate: cargo-audit
+          crate: cargo-deny
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
 
-      - name: Check security advisories
-        run: cargo audit
+      - name: Audit dependencies
+        run: cargo deny check
 
   rustfmt:
     name: Format

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,41 @@
+# cargo-deny configuration (https://github.com/EmbarkStudios/cargo-deny)
+
+# Only check for Linux targets
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+]
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+yanked = "deny"
+notice = "warn"
+
+ignore = []
+
+[licenses]
+unlicensed = "deny"
+allow = ["MIT", "Apache-2.0", "ISC", "BSD-3-Clause"]
+
+private = { ignore = true }  # Ignore workspace crates
+exceptions = [
+    { name = "ring", allow = ["LicenseRef-ring"]}
+]
+
+[[licenses.clarify]]  # ring is licensed under multiple MIT-like licenses
+name = "ring"
+expression = "LicenseRef-ring"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+
+[bans]
+multiple-versions = "warn"
+deny = []
+
+[sources]
+# Only crates.io is allowed
+unknown-registry = "deny"
+unknown-git = "deny"


### PR DESCRIPTION
Replace `cargo-audit` with [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny), as the latter is more customizable and also support license checks.