### PR TITLE
enhancement(handler): remove global commands on development

### DIFF
--- a/handler/src/interaction/handle.rs
+++ b/handler/src/interaction/handle.rs
@@ -64,6 +64,11 @@ pub async fn register_commands(
 
     let result = match command_guild {
         Some(id) => {
+            // Remove all previous global commands to avoid duplicates
+            if let Err(error) = client.set_global_commands(&[]).exec().await {
+                warn!(error = %error, "failed to remove global commands");
+            }
+
             client
                 .set_guild_commands(Id::new(id), &commands)
                 .exec()

--- a/raidprotect/src/config.rs
+++ b/raidprotect/src/config.rs
@@ -19,7 +19,11 @@ pub struct Config {
     pub token: String,
     /// ID of the guild in which commands should be created.
     ///
+    /// This is useful when developing to reflect changes to commands instantly.
     /// If not set, commands will be created globally.
+    ///
+    /// **Warning:** if set, all previously created global commands will be
+    /// removed to avoid duplicates. Do not enable this in production.
     pub command_guild: Option<u64>,
     /// MongoDB connection uri.
     ///


### PR DESCRIPTION
The `command_guild` option allow creating guild commands instead of global commands, so changes are instantly reflected. This is used in development environments, but in case the bot has run once without this option by mistake, all commands would be duplicated.

This avoids this duplication by removing all global commands on startup is `command_guild` is set.