### PR TITLE
feat(cache): current member cache permissions

### DIFF
--- a/cache/src/model/guild.rs
+++ b/cache/src/model/guild.rs
@@ -86,7 +86,7 @@ impl RedisModel for CachedGuild {
 /// This model is not cached within guilds to limit
 /// data to send when requesting a [`CachedGuild`].
 ///
-/// This type implement [`Ord`] and [`PartialOrd`] for comparaisons
+/// This type implement [`Ord`] and [`PartialOrd`] for comparisons
 /// between two role based on their position.
 ///
 /// [`Role`]: twilight_model::guild::Role

--- a/cache/src/redis.rs
+++ b/cache/src/redis.rs
@@ -141,6 +141,16 @@ impl RedisClient {
     ) -> RedisResult<Option<CachePermissions>> {
         CachePermissions::new(self, guild_id, user_id, member_roles).await
     }
+
+    /// Get a [`CachePermissions`] for the bot member in a given guild.
+    ///
+    /// If the guild is not found in the cache, [`None`] is returned.
+    pub async fn current_member_permissions(
+        &self,
+        guild_id: Id<GuildMarker>,
+    ) -> RedisResult<Option<CachePermissions>> {
+        CachePermissions::current_member(self, guild_id).await
+    }
 }
 
 /// This trait is implemented by types representing a Redis model.


### PR DESCRIPTION
Adds a `current_member_permissions` method to the Redis cache, that returns `CachePermissions` for the bot member in a given guild.
