### PR TITLE
feat(interaction): register commands globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,7 @@ RaidProtect load configuration from environment variables prefixed with `RAIDPRO
 
 **The only required configuration is the bot token** with the `RAIDPROTECT_TOKEN`
 environment variable. This token can be obtained from the Discord Developer
-Portal. You may also set the `RAIDPROTECT_COMMAND_GUILD` with the id of the
-server you use for testing the bot. This will register slash commands as guild
-rather than global commands, so they will be updated instantly.
+Portal.
 
 For a complete and up-to-date list of available configuration options, refer to
 the [`raidprotect/src/config.rs`](raidprotect/src/config.rs) file.

--- a/interaction/src/handle.rs
+++ b/interaction/src/handle.rs
@@ -56,13 +56,7 @@ pub async fn handle_command(command: ApplicationCommand, state: Arc<ClusterState
 }
 
 /// Register commands to the Discord API.
-///
-/// The commands will be registered globally unless a `command_guild` is set.
-pub async fn register_commands(
-    state: &ClusterState,
-    application_id: Id<ApplicationMarker>,
-    command_guild: Option<u64>,
-) {
+pub async fn register_commands(state: &ClusterState, application_id: Id<ApplicationMarker>) {
     let commands: Vec<Command> = vec![
         HelpCommand::create_command().into(),
         ProfileCommand::create_command().into(),
@@ -71,22 +65,7 @@ pub async fn register_commands(
 
     let client = state.http().interaction(application_id);
 
-    let result = match command_guild {
-        Some(id) => {
-            // Remove all previous global commands to avoid duplicates
-            if let Err(error) = client.set_global_commands(&[]).exec().await {
-                warn!(error = %error, "failed to remove global commands");
-            }
-
-            client
-                .set_guild_commands(Id::new(id), &commands)
-                .exec()
-                .await
-        }
-        None => client.set_global_commands(&commands).exec().await,
-    };
-
-    if let Err(error) = result {
+    if let Err(error) = client.set_global_commands(&commands).exec().await {
         error!(error = %error, "failed to register commands");
     }
 }

--- a/raidprotect/src/cluster.rs
+++ b/raidprotect/src/cluster.rs
@@ -76,7 +76,7 @@ impl ShardCluster {
 
         let state = ClusterState::new(redis, mongodb, http, current_user);
 
-        register_commands(&state, application.id, config.command_guild).await;
+        register_commands(&state, application.id).await;
 
         Ok(Self {
             cluster: Arc::new(cluster),

--- a/raidprotect/src/config.rs
+++ b/raidprotect/src/config.rs
@@ -18,14 +18,6 @@ pub fn parse_config() -> Result<Config, envy::Error> {
 pub struct Config {
     /// Discord bot token.
     pub token: String,
-    /// ID of the guild in which commands should be created.
-    ///
-    /// This is useful when developing to reflect changes to commands instantly.
-    /// If not set, commands will be created globally.
-    ///
-    /// **Warning:** if set, all previously created global commands will be
-    /// removed to avoid duplicates. Do not enable this in production.
-    pub command_guild: Option<u64>,
     /// Redis connection uri.
     ///
     /// The connection uri should use the `redis://` scheme. Defaults to


### PR DESCRIPTION
Discord shipped commands v2 that make global command rollout instant (see https://github.com/discord/discord-api-docs/pull/4896). The `command_guild` setting is thus no longer necessary for instant updates during development, commands are now always registered as global commands.