### PR TITLE
chore: group imports with rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,12 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: hecrj/setup-rust-action@v1
+        with:
+          rust-version: nightly
+          components: rustfmt
 
       - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
       - name: Run codespell
         uses: codespell-project/actions-codespell@master

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+unstable_features = true
+
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"

--- a/cache/src/process/event.rs
+++ b/cache/src/process/event.rs
@@ -1,7 +1,6 @@
 //! Update the cache based on incoming event data.
 
 use async_trait::async_trait;
-
 use tracing::error;
 use twilight_model::{
     gateway::payload::incoming::{

--- a/event/src/message/mod.rs
+++ b/event/src/message/mod.rs
@@ -8,7 +8,6 @@ mod handle;
 pub mod parser;
 
 pub use handle::handle_message;
-
 use twilight_model::channel::message::MessageType;
 
 /// Messages types processed by the bot.

--- a/interaction/src/embed/error.rs
+++ b/interaction/src/embed/error.rs
@@ -1,12 +1,10 @@
 //! Error embeds.
 
+use raidprotect_translations::Lang;
 use twilight_util::builder::embed::{EmbedBuilder, EmbedFooterBuilder};
 
-use raidprotect_translations::Lang;
-
-use crate::response::InteractionResponse;
-
 use super::COLOR_RED;
+use crate::response::InteractionResponse;
 
 /// Internal error embed
 pub fn internal_error() -> InteractionResponse {

--- a/interaction/src/embed/kick.rs
+++ b/interaction/src/embed/kick.rs
@@ -4,9 +4,8 @@ use raidprotect_translations::Lang;
 use raidprotect_util::text::TextProcessExt;
 use twilight_util::builder::embed::EmbedBuilder;
 
-use crate::response::InteractionResponse;
-
 use super::COLOR_RED;
+use crate::response::InteractionResponse;
 
 /// User is not a server member.
 pub fn not_member(user: String) -> InteractionResponse {

--- a/interaction/src/handle.rs
+++ b/interaction/src/handle.rs
@@ -12,14 +12,13 @@ use twilight_model::{
     id::{marker::ApplicationMarker, Id},
 };
 
-use crate::{command::kick::KickCommand, embed};
-
 use super::{
     command::{help::HelpCommand, profile::ProfileCommand},
     component::post_in_chat::PostInChat,
     context::InteractionContext,
     response::{InteractionResponder, IntoResponse},
 };
+use crate::{command::kick::KickCommand, embed};
 
 /// Handle incoming [`ApplicationCommand`]
 ///

--- a/model/src/mongodb.rs
+++ b/model/src/mongodb.rs
@@ -7,7 +7,6 @@
 use std::time::Duration;
 
 pub use mongodb::error::Error as MongoDbError;
-
 use mongodb::{
     bson::{doc, to_bson, to_document},
     options, Client, Database,

--- a/util/src/serde.rs
+++ b/util/src/serde.rs
@@ -120,8 +120,6 @@ impl SerializeAs<Timestamp> for TimestampAsI64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{IdAsI64, IdAsU64, TimestampAsI64};
-
     use serde::{Deserialize, Serialize};
     use serde_test::{assert_de_tokens_error, assert_ser_tokens_error, assert_tokens, Token};
     use serde_with::serde_as;
@@ -129,6 +127,8 @@ mod tests {
         datetime::Timestamp,
         id::{marker::GenericMarker, Id},
     };
+
+    use super::{IdAsI64, IdAsU64, TimestampAsI64};
 
     #[serde_as]
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
Group imports using `rustfmt` unstable features. Nightly toolchain is now used in the CI to check formatting.