### PR TITLE
chore: update rust-analyzer extension id

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -26,7 +26,7 @@ github:
 
 vscode:
   extensions:
-    - matklad.rust-analyzer
+    - rust-lang.rust-analyzer
     - editorconfig.editorconfig
     - tamasfe.even-better-toml
     - serayuzgur.crates

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
-        "matklad.rust-analyzer",
+        "rust-lang.rust-analyzer",
         "editorconfig.editorconfig",
         "tamasfe.even-better-toml",
         "Lokalise.i18n-ally",


### PR DESCRIPTION
rust-analyzer extension moved to Rust Lang organization, thus its id changed to `rust-lang.rust-analyzer`
