### PR TITLE
feat(interaction): support enforce_reason config

### DIFF
--- a/interaction/src/command/kick.rs
+++ b/interaction/src/command/kick.rs
@@ -98,7 +98,7 @@ impl KickCommand {
         // Send reason modal.
         match parsed.reason {
             Some(_reason) => Ok(InteractionResponse::EphemeralDeferredMessage),
-            None => KickCommand::reason_modal(user.name),
+            None => KickCommand::reason_modal(user.name, guild.config().enforce_reason),
         }
     }
 
@@ -106,7 +106,10 @@ impl KickCommand {
     ///
     /// This modal is only shown if the user has not specified a reason in the
     /// initial command.
-    fn reason_modal(username: String) -> Result<InteractionResponse, KickCommandError> {
+    fn reason_modal(
+        username: String,
+        enforce_reason: bool,
+    ) -> Result<InteractionResponse, KickCommandError> {
         let components = vec![
             Component::ActionRow(ActionRow {
                 components: vec![Component::TextInput(TextInput {
@@ -115,7 +118,7 @@ impl KickCommand {
                     max_length: Some(100),
                     min_length: None,
                     placeholder: Some(Lang::Fr.modal_reason_placeholder().to_string()),
-                    required: Some(false),
+                    required: Some(enforce_reason),
                     style: TextInputStyle::Short,
                     value: None,
                 })],

--- a/interaction/src/context.rs
+++ b/interaction/src/context.rs
@@ -45,17 +45,6 @@ pub struct InteractionContext<D> {
     pub locale: String,
 }
 
-/// Additional context for commands triggered in a guild.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GuildContext {
-    /// ID of the guild.
-    pub id: Id<GuildMarker>,
-    /// The guild configuration from database.
-    pub guild: collection::Guild,
-    /// The member that triggered the command.
-    pub member: PartialMember,
-}
-
 impl<D> InteractionContext<D> {
     /// Get the [`InteractionClient`] associated with the current context.
     pub fn interaction<'state>(&self, state: &'state ClusterState) -> InteractionClient<'state> {
@@ -186,6 +175,26 @@ impl InteractionContext<MessageComponentInteractionData> {
             user,
             locale: component.locale,
         })
+    }
+}
+
+/// Additional context for commands triggered in a guild.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuildContext {
+    /// ID of the guild.
+    pub id: Id<GuildMarker>,
+    /// The guild configuration from database.
+    pub guild: collection::Guild,
+    /// The member that triggered the command.
+    pub member: PartialMember,
+}
+
+impl GuildContext {
+    /// Get the [`Config`] of the guild.
+    ///
+    /// [`Config`]: collection::Config
+    pub fn config(&self) -> &collection::Config {
+        &self.guild.config
     }
 }
 

--- a/model/src/collection/guild.rs
+++ b/model/src/collection/guild.rs
@@ -49,8 +49,7 @@ pub struct Config {
     /// has not yet be done.
     #[serde_as(as = "Option<IdAsI64>")]
     pub logs_chan: Option<Id<ChannelMarker>>,
-    /// The moderator roles, allowed to access to guild modlogs
-    /// and to perform some sanction (mute and warn).
+    /// The moderator roles, allowed to access to guild modlogs.
     #[serde_as(as = "Vec<IdAsI64>")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub moderator_roles: Vec<Id<RoleMarker>>,


### PR DESCRIPTION
Add missing support for the `enforce_reason` configuration option to the kick command.
