### PR TITLE
deps: use full versions in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -149,13 +149,12 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60a2c7c80a7850b56df4b8e98e8e4932c34877b8add4f13e8350499cc1e4572"
+checksum = "a24ecf39f5a314493ede1bb015984735d41aa6aedb59cafb95492d40cd893330"
 dependencies = [
  "ahash",
  "base64",
- "chrono",
  "hex",
  "indexmap",
  "lazy_static",
@@ -163,14 +162,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "time 0.3.9",
  "uuid",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "byteorder"
@@ -846,9 +846,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
 dependencies = [
  "adler",
 ]
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a2fe500edae1ffc8e4bbc731e54a44638e5ec59fbff967f1cb8306867f5b53"
+checksum = "28f3943e379e9dcaaab9dc319c308a8caaf9e7ff083c6838dff740afbba59df7"
 dependencies = [
  "async-trait",
  "base64",
@@ -879,7 +879,6 @@ dependencies = [
  "derivative",
  "futures-core",
  "futures-executor",
- "futures-io",
  "futures-util",
  "hex",
  "hmac",
@@ -993,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1597,9 +1596,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
+checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1660,7 +1659,14 @@ dependencies = [
  "itoa 1.0.2",
  "libc",
  "num_threads",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyjson"
@@ -1685,9 +1691,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.18.2"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903bf0427cf68dddd5aa6a93220756f8be0c34fcfa9f5e6191e103e15a31395"
+checksum = "0f392c8f16bda3456c0b00c6de39cb100449b98de55ac41c6cdd2bfcf53a1245"
 dependencies = [
  "bytes",
  "libc",

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,10 @@ unmaintained = "deny"
 yanked = "deny"
 notice = "warn"
 
+ignore = [
+    "RUSTSEC-2020-0071",  # `mongodb` crate not affected by this vulnerability
+]
+
 [licenses]
 unlicensed = "deny"
 allow = ["MIT", "Apache-2.0", "ISC", "BSD-3-Clause"]

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -8,28 +8,28 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
-mongodb = { version = "2.2.0", features = ["zstd-compression"] }
-thiserror = "1"
-tracing = "0.1"
+async-trait = "0.1.56"
+mongodb = { version = "2.2.2", features = ["zstd-compression"] }
+thiserror = "1.0.31"
+tracing = "0.1.34"
 
 # Models
-serde = { version = "1", features = ["derive"] }
-serde_with = "1"
-url = { version = "2", features = ["serde"] }
+serde = { version = "1.0.137", features = ["derive"] }
+serde_with = "1.14.0"
+url = { version = "2.2.2", features = ["serde"] }
 
 # Redis (client + serialization)
-bb8 = "0.8"
-bb8-redis = "0.11"
-redis = { version = "0.21", features = ["tokio-comp"], default-features = false }
-rmp-serde = "1.1"
-zstd = "0.11"
+bb8 = "0.8.0"
+bb8-redis = "0.11.0"
+redis = { version = "0.21.5", features = ["tokio-comp"], default-features = false }
+rmp-serde = "1.1.0"
+zstd = "0.11.2"
 
 # Twilight
-twilight-http = "0.11"
-twilight-model = "0.11"
-twilight-util = { version = "0.11", features = ["permission-calculator"] }
-twilight-validate = "0.11"
+twilight-http = "0.11.0"
+twilight-model = "0.11.0"
+twilight-util = { version = "0.11.0", features = ["permission-calculator"] }
+twilight-validate = "0.11.0"
 
 [dev-dependencies]
-serde_test = "1"
+serde_test = "1.0.137"

--- a/raidprotect/Cargo.toml
+++ b/raidprotect/Cargo.toml
@@ -10,39 +10,39 @@ publish = false
 [dependencies]
 raidprotect-model = { path = "../model" }
 
-anyhow = "1"
-async-trait = "0.1"
-nanoid = "0.4"
-once_cell = "1.12"
-rosetta-i18n = "0.1"
-thiserror = "1"
+anyhow = "1.0.57"
+async-trait = "0.1.56"
+nanoid = "0.4.0"
+once_cell = "1.12.0"
+rosetta-i18n = "0.1.2"
+thiserror = "1.0.31"
 
 # Tokio ecosystem
-futures = "0.3"
-tokio = { version = "1.17", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
-tracing = { version = "0.1" }
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["std", "fmt", "ansi"], default-features = false }
+futures = "0.3.21"
+tokio = { version = "1.19.0", features = ["macros", "rt-multi-thread", "sync", "time", "signal"] }
+tracing = "0.1.34"
+tracing-appender = "0.2.2"
+tracing-subscriber = { version = "0.3.11", features = ["std", "fmt", "ansi"], default-features = false }
 
 # Twilight
-twilight-gateway = "0.11"
-twilight-http = "0.11"
-twilight-interactions = "0.11"
-twilight-mention = "0.11"
-twilight-model = "0.11"
-twilight-util = { version = "0.11", features = ["builder", "snowflake"] }
-twilight-validate = "0.11"
+twilight-gateway = "0.11.0"
+twilight-http = "0.11.0"
+twilight-interactions = "0.11.0"
+twilight-mention = "0.11.0"
+twilight-model = "0.11.0"
+twilight-util = { version = "0.11.0", features = ["builder", "snowflake"] }
+twilight-validate = "0.11.0"
 
 # Configuration
-envy = "0.4"
-dotenv = "0.15"
-serde = { version = "1", features = ["derive"] }
+envy = "0.4.2"
+dotenv = "0.15.0"
+serde = { version = "1.0.137", features = ["derive"] }
 
 # Message parsing
-any_ascii = "0.3"
-linkify = "0.8"
-unicode-segmentation = "1.9"
-url = "2.2"
+any_ascii = "0.3.1"
+linkify = "0.8.1"
+unicode-segmentation = "1.9.0"
+url = "2.2.2"
 
 [build-dependencies]
-rosetta-build = "0.1"
+rosetta-build = "0.1.2"


### PR DESCRIPTION
Use full dependencies versions in `Cargo.toml` (including patch version number). This PR also update dependencies to their latest version.
