### PR TITLE
ci: scan dependencies with github security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,11 @@ jobs:
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v1
 
-      - name: Audit dependencies
+      - name: Check dependencies
         run: cargo deny check
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v1
 
   rustfmt:
     name: Format


### PR DESCRIPTION
GitHub supply chain security [now supports Rust](https://github.blog/2022-06-06-github-brings-supply-chain-security-features-to-the-rust-community/). This enables dependency review with [`dependency-review-action`](https://github.com/actions/dependency-review-action) on PRs.