### PR TITLE
fix(ci): skip dependencies review action on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         run: cargo deny check
 
       - name: Review dependencies
+        if: ${{ github.event_name == 'pull_request' }}  # Does not work on 'push'
         uses: actions/dependency-review-action@v1
 
   rustfmt:


### PR DESCRIPTION
`actions/dependency-review-action@v1` only works with `pull_request` event