### PR TITLE
feat(cache): pending sanction model

### DIFF
--- a/model/src/cache/model/component.rs
+++ b/model/src/cache/model/component.rs
@@ -5,21 +5,24 @@ use serde_with::serde_as;
 use twilight_model::{
     http::interaction::InteractionResponseData,
     id::{marker::UserMarker, Id},
+    user::User,
 };
 
-use crate::{cache::RedisModel, serde::IdAsU64};
+use crate::{cache::RedisModel, mongodb::modlog::ModlogType, serde::IdAsU64};
 
 /// State of a component waiting for user interaction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PendingComponent {
     PostInChatButton(PostInChatButton),
+    Sanction(PendingSanction),
 }
 
 impl PendingComponent {
     /// Get the component unique identifier.
     pub fn id(&self) -> &str {
         match self {
-            PendingComponent::PostInChatButton(component) => &component.id,
+            Self::PostInChatButton(component) => &component.id,
+            Self::Sanction(component) => &component.id,
         }
     }
 }
@@ -40,8 +43,6 @@ impl RedisModel for PendingComponent {
 }
 
 /// State for the "post in chat" button.
-///
-/// See the `raidprotect-handler` for more information.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PostInChatButton {
@@ -52,4 +53,14 @@ pub struct PostInChatButton {
     /// Id of the initial interaction author.
     #[serde_as(as = "IdAsU64")]
     pub author_id: Id<UserMarker>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingSanction {
+    /// Component unique identifier.
+    pub id: String,
+    /// Type of the pending modlog.
+    pub kind: ModlogType,
+    /// User targeted by the sanction.
+    pub user: User,
 }

--- a/model/src/mongodb/modlog.rs
+++ b/model/src/mongodb/modlog.rs
@@ -25,7 +25,7 @@ pub struct Modlog {
     #[serde(rename = "_id")]
     pub id: Option<ObjectId>,
     /// Type of moderation log.
-    pub kind: ModlogKind,
+    pub kind: ModlogType,
     /// Guild where the moderation log was issued.
     #[serde_as(as = "IdAsI64")]
     pub guild_id: Id<GuildMarker>,
@@ -50,7 +50,7 @@ impl Modlog {
 /// Type of modlog entry.
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
-pub enum ModlogKind {
+pub enum ModlogType {
     Kick,
 }
 

--- a/model/tests/modlog.rs
+++ b/model/tests/modlog.rs
@@ -1,6 +1,6 @@
 use mongodb::bson::{self, oid::ObjectId, DateTime};
 use pretty_assertions::assert_eq;
-use raidprotect_model::mongodb::modlog::{Modlog, ModlogKind, ModlogUser};
+use raidprotect_model::mongodb::modlog::{Modlog, ModlogType, ModlogUser};
 use serde_test::{assert_tokens, Configure, Token};
 use time::OffsetDateTime;
 use twilight_model::{id::Id, util::ImageHash};
@@ -9,7 +9,7 @@ use twilight_model::{id::Id, util::ImageHash};
 fn test_modlog_full() {
     let modlog = Modlog {
         id: Some(ObjectId::parse_str("62aca55a551e9a0102351bda").unwrap()),
-        kind: ModlogKind::Kick,
+        kind: ModlogType::Kick,
         guild_id: Id::new(1),
         user: ModlogUser {
             id: Id::new(2),
@@ -49,7 +49,7 @@ fn test_modlog_full() {
             Token::StructEnd,
             // kind
             Token::Str("kind"),
-            Token::Enum { name: "ModlogKind" },
+            Token::Enum { name: "ModlogType" },
             Token::Str("kick"),
             Token::Unit,
             // guild_id
@@ -127,7 +127,7 @@ fn test_modlog_full() {
 fn test_modlog_bson() {
     let modlog = Modlog {
         id: Some(ObjectId::parse_str("62aca55a551e9a0102351bda").unwrap()),
-        kind: ModlogKind::Kick,
+        kind: ModlogType::Kick,
         guild_id: Id::new(1),
         user: ModlogUser {
             id: Id::new(2),

--- a/raidprotect/src/interaction/handle.rs
+++ b/raidprotect/src/interaction/handle.rs
@@ -92,6 +92,7 @@ pub async fn handle_component(component: MessageComponentInteraction, state: Arc
     let response = match component {
         Ok(Some(component)) => match component {
             PendingComponent::PostInChatButton(c) => PostInChat::handle(c),
+            PendingComponent::Sanction(_) => unimplemented!(),
         },
         Ok(None) => embed::error::expired_component(),
         Err(error) => {


### PR DESCRIPTION
Adds the `PendingSanction` model for storing sanction state while waiting for the modal to be filled.