### PR TITLE
deps: use webpki instead of native tls certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,22 +303,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "core-foundation"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,9 +744,9 @@ dependencies = [
  "http",
  "hyper",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1000,7 +984,7 @@ dependencies = [
  "rand",
  "rustc_version_runtime",
  "rustls",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "serde",
  "serde_bytes",
  "serde_with",
@@ -1083,12 +1067,6 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ordered-float"
@@ -1477,18 +1455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-native-certs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.0",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "rustls-pemfile"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,29 +1464,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
-dependencies = [
- "base64",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
-
-[[package]]
-name = "schannel"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
-dependencies = [
- "lazy_static",
- "windows-sys",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1536,29 +1483,6 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
-dependencies = [
- "bitflags",
- "core-foundation",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -1912,11 +1836,11 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tungstenite",
  "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2133,7 +2057,6 @@ dependencies = [
  "futures-util",
  "leaky-bucket-lite",
  "rustls",
- "rustls-native-certs",
  "serde",
  "serde_json",
  "tokio",
@@ -2143,6 +2066,7 @@ dependencies = [
  "twilight-http",
  "twilight-model",
  "url",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -27,7 +27,7 @@ rmp-serde = "1.1.0"
 zstd = "0.11.2"
 
 # Twilight
-twilight-http = "0.11.1"
+twilight-http = { version = "0.11.1", features = ["rustls-webpki-roots", "decompression"], default-features = false }
 twilight-model = "0.11.1"
 twilight-util = { version = "0.11.1", features = ["permission-calculator"] }
 twilight-validate = "0.11.1"

--- a/raidprotect/Cargo.toml
+++ b/raidprotect/Cargo.toml
@@ -22,8 +22,8 @@ tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread", "sync", "
 tracing = "0.1.35"
 
 # Twilight
-twilight-gateway = "0.11.1"
-twilight-http = "0.11.1"
+twilight-gateway = { version = "0.11.1", features = ["rustls-webpki-roots", "zlib-stock"], default-features = false }
+twilight-http = { version = "0.11.1", features = ["rustls-webpki-roots", "decompression"], default-features = false }
 twilight-interactions = "0.11.0"
 twilight-mention = "0.11.1"
 twilight-model = "0.11.1"


### PR DESCRIPTION
Use [`webpki-roots`](https://lib.rs/crates/webpki-roots) (Mozilla's root certificates) instead of native ones. This standardizes TLS certificates across dependencies, since [`mongodb`](https://lib.rs/crates/mongodb) only supports webpki roots. It also improves security when running in out-of-date or minimal environments such as containers by embedding root certificates in the binary.
