### PR TITLE
refactor(cache): remove zstd compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,6 @@ dependencies = [
  "twilight-util",
  "twilight-validate",
  "url",
- "zstd",
 ]
 
 [[package]]

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -24,7 +24,6 @@ bb8 = "0.8.0"
 bb8-redis = "0.11.0"
 redis = { version = "0.21.5", features = ["tokio-comp"], default-features = false }
 rmp-serde = "1.1.0"
-zstd = "0.11.2"
 
 # Twilight
 twilight-http = { version = "0.12.0", features = ["rustls-webpki-roots", "decompression"], default-features = false }

--- a/model/src/cache/redis.rs
+++ b/model/src/cache/redis.rs
@@ -191,8 +191,8 @@ pub trait RedisModel: Debug + Serialize + DeserializeOwned {
 
     /// Serialize this model.
     ///
-    /// The default implementation serialize the model in MessagePack using
-    /// [`rmp_serde`] and compress it with [`zstd`].
+    /// The default implementation serializes the model in MessagePack using
+    /// [`rmp_serde`].
     fn serialize_model(&self) -> Result<Vec<u8>, anyhow::Error> {
         let serialized = rmp_serde::to_vec_named(self)?;
         trace!(value = ?self, serialized = ?serialized, "serializing model");
@@ -202,8 +202,8 @@ pub trait RedisModel: Debug + Serialize + DeserializeOwned {
 
     /// Deserialize this model.
     ///
-    /// The default implementation decompress the model with [`zstd`] and
-    /// deserialize it from MessagePack with [`rmp_serde`].
+    /// The default implementation deserializes the model from MessagePack with
+    /// [`rmp_serde`].
     fn deserialize_model(value: Vec<u8>) -> Result<Self, anyhow::Error> {
         trace!(value = ?value, "deserializing model");
 

--- a/model/src/cache/redis.rs
+++ b/model/src/cache/redis.rs
@@ -197,7 +197,7 @@ pub trait RedisModel: Debug + Serialize + DeserializeOwned {
         let serialized = rmp_serde::to_vec_named(self)?;
         trace!(value = ?self, serialized = ?serialized, "serializing model");
 
-        Ok(zstd::encode_all(&*serialized, 0)?)
+        Ok(serialized)
     }
 
     /// Deserialize this model.
@@ -206,8 +206,7 @@ pub trait RedisModel: Debug + Serialize + DeserializeOwned {
     /// deserialize it from MessagePack with [`rmp_serde`].
     fn deserialize_model(value: Vec<u8>) -> Result<Self, anyhow::Error> {
         trace!(value = ?value, "deserializing model");
-        let decoded = zstd::decode_all(&*value)?;
 
-        Ok(rmp_serde::from_slice(&decoded)?)
+        Ok(rmp_serde::from_slice(&value)?)
     }
 }


### PR DESCRIPTION
Removes the zstd compression on the Redis cache.

- Compression makes debugging harder.
- Stored data is small, compression doesn't save much space (sometimes "compressed" data is larger than the original one).
- Reduce CPU usage.
