### PR TITLE
deps: use zlib compression with mongodb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,9 +344,6 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -1098,15 +1095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1268,7 @@ dependencies = [
  "bson",
  "chrono",
  "derivative",
+ "flate2",
  "futures-core",
  "futures-executor",
  "futures-util",
@@ -1312,7 +1301,6 @@ dependencies = [
  "typed-builder",
  "uuid",
  "webpki-roots",
- "zstd",
 ]
 
 [[package]]
@@ -3145,33 +3133,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/model/Cargo.toml
+++ b/model/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 async-trait = "0.1.56"
-mongodb = { version = "2.2.2", features = ["zstd-compression"] }
+mongodb = { version = "2.2.2", features = ["zlib-compression"] }
 tracing = "0.1.35"
 
 # Models

--- a/model/src/mongodb/client.rs
+++ b/model/src/mongodb/client.rs
@@ -40,7 +40,7 @@ impl MongoDbClient {
         config.app_name = Some(config.app_name.unwrap_or_else(|| "raidprotect".to_string()));
         config.connect_timeout = Some(Duration::from_secs(2));
         config.server_selection_timeout = Some(Duration::from_secs(2));
-        config.compressors = Some(vec![options::Compressor::Zstd { level: None }]);
+        config.compressors = Some(vec![options::Compressor::Zlib { level: None }]);
         config.default_database = Some(database.clone());
 
         let client = Client::with_options(config)?;


### PR DESCRIPTION
Remove the `zstd` dependency from `mongodb` (see #111) to improve compile times (`zstd-sys` takes almost 25 sec to compile on my computer). Use zlib compression instead, as `flate2` is already a `twilight-gateway` dependency.