### PR TITLE
refactor: flatten configuration model

### DIFF
--- a/model/src/mongodb/guild.rs
+++ b/model/src/mongodb/guild.rs
@@ -9,7 +9,7 @@ use twilight_model::id::{
 
 use crate::serde::IdAsI64;
 
-/// Guild data and configuration.
+/// Guild configuration.
 ///
 /// This struct correspond to documents stored in the `guilds` collection.
 #[serde_as]
@@ -19,9 +19,20 @@ pub struct Guild {
     #[serde_as(as = "IdAsI64")]
     #[serde(rename = "_id")]
     pub id: Id<GuildMarker>,
-    /// The guild configuration.
+    /// The channel where RaidProtect send logs messages.
+    ///
+    /// The configuration validation will fail if no logs chan is set,
+    /// but this field may be [`None`] when the initial configuration
+    /// has not yet be done.
+    #[serde_as(as = "Option<IdAsI64>")]
     #[serde(default)]
-    pub config: Config,
+    pub logs_chan: Option<Id<ChannelMarker>>,
+    /// The moderation module configuration.
+    #[serde(default, flatten, with = "prefix_moderation")]
+    pub moderation: Moderation,
+    /// The captcha module configuration.
+    #[serde(default, flatten, with = "prefix_captcha")]
+    pub captcha: Captcha,
 }
 
 impl Guild {
@@ -32,30 +43,22 @@ impl Guild {
     pub fn new(id: Id<GuildMarker>) -> Self {
         Self {
             id,
-            config: Config::default(),
+            logs_chan: None,
+            moderation: Moderation::default(),
+            captcha: Captcha::default(),
         }
     }
 }
 
-/// A guild configuration.
-///
-/// Stored in the `guilds` collection within a [`Guild`].
+/// Configuration for the moderation module.
 #[serde_as]
-#[skip_serializing_none]
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
-pub struct Config {
-    /// The channel where RaidProtect send logs messages.
-    ///
-    /// The configuration validation will fail if no logs chan is set,
-    /// but this field may be [`None`] when the initial configuration
-    /// has not yet be done.
-    #[serde_as(as = "Option<IdAsI64>")]
-    pub logs_chan: Option<Id<ChannelMarker>>,
+pub struct Moderation {
     /// The moderator roles, allowed to access to guild modlogs.
     #[serde_as(as = "Vec<IdAsI64>")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub moderator_roles: Vec<Id<RoleMarker>>,
+    pub roles: Vec<Id<RoleMarker>>,
     /// Whether sanction commands requires a reason or not.
     ///
     /// If set to `true`, moderators must specify a reason with each sanction.
@@ -63,22 +66,20 @@ pub struct Config {
     /// Whether the moderator who has performed a sanction is hidden for the sanctioned user.
     ///
     /// This is enabled by default.
-    pub anonymize_moderator: bool,
-    #[serde(flatten, with = "prefix_captcha")]
-    pub captcha: Captcha,
+    pub anonymize: bool,
 }
 
-impl Default for Config {
+impl Default for Moderation {
     fn default() -> Self {
-        Config {
-            logs_chan: None,
-            moderator_roles: Vec::new(),
+        Self {
+            roles: Vec::new(),
             enforce_reason: false,
-            anonymize_moderator: true,
-            captcha: Captcha::default(),
+            anonymize: true,
         }
     }
 }
+
+with_prefix!(prefix_moderation "moderation_");
 
 /// Configuration for the captcha module.
 #[serde_as]
@@ -92,15 +93,15 @@ pub struct Captcha {
     ///
     /// This is used to disable the captcha if the channel is deleted.
     #[serde_as(as = "Option<IdAsI64>")]
-    pub verification_channel: Option<Id<ChannelMarker>>,
+    pub channel: Option<Id<ChannelMarker>>,
     /// The captcha message id.
     ///
     /// This is used to recreate the captcha message if it is deleted.
     #[serde_as(as = "Option<IdAsI64>")]
-    pub verification_message: Option<Id<MessageMarker>>,
+    pub message: Option<Id<MessageMarker>>,
     /// Role given to users that haven't completed the captcha.
     #[serde_as(as = "Option<IdAsI64>")]
-    pub unverified_role: Option<Id<RoleMarker>>,
+    pub role: Option<Id<RoleMarker>>,
     /// Roles given to users after completing the captcha.
     #[serde_as(as = "Vec<IdAsI64>")]
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -109,7 +110,7 @@ pub struct Captcha {
     ///
     /// If set, the captcha will send detailed logs to this channel.
     #[serde_as(as = "Option<IdAsI64>")]
-    pub logs_channel: Option<Id<ChannelMarker>>,
+    pub logs: Option<Id<ChannelMarker>>,
 }
 
 with_prefix!(prefix_captcha "captcha_");

--- a/model/tests/guild.rs
+++ b/model/tests/guild.rs
@@ -1,6 +1,6 @@
 use mongodb::bson;
 use pretty_assertions::assert_eq;
-use raidprotect_model::mongodb::guild::{Captcha, Config, Guild};
+use raidprotect_model::mongodb::guild::{Captcha, Guild, Moderation};
 use serde_test::{assert_tokens, Token};
 use twilight_model::id::Id;
 
@@ -11,22 +11,18 @@ fn test_guild_default() {
     assert_tokens(
         &guild,
         &[
-            Token::Struct {
-                name: "Guild",
-                len: 2,
-            },
+            Token::Map { len: None },
             Token::Str("_id"),
             Token::I64(1),
-            Token::Str("config"),
-            Token::Map { len: None },
-            Token::Str("enforce_reason"),
+            Token::Str("logs_chan"),
+            Token::None,
+            Token::Str("moderation_enforce_reason"),
             Token::Bool(false),
-            Token::Str("anonymize_moderator"),
+            Token::Str("moderation_anonymize"),
             Token::Bool(true),
             Token::Str("captcha_enabled"),
             Token::Bool(false),
             Token::MapEnd,
-            Token::StructEnd,
         ],
     );
 }
@@ -35,54 +31,49 @@ fn test_guild_default() {
 fn test_guild_full() {
     let guild = Guild {
         id: Id::new(1),
-        config: Config {
-            logs_chan: Some(Id::new(2)),
-            moderator_roles: vec![Id::new(3), Id::new(4)],
+        logs_chan: Some(Id::new(2)),
+        moderation: Moderation {
+            roles: vec![Id::new(3), Id::new(4)],
             enforce_reason: true,
-            anonymize_moderator: false,
-            captcha: Captcha {
-                enabled: true,
-                verification_channel: Some(Id::new(5)),
-                verification_message: Some(Id::new(6)),
-                unverified_role: Some(Id::new(7)),
-                verified_roles: vec![Id::new(8), Id::new(9)],
-                logs_channel: Some(Id::new(10)),
-            },
+            anonymize: false,
+        },
+        captcha: Captcha {
+            enabled: true,
+            channel: Some(Id::new(5)),
+            message: Some(Id::new(6)),
+            role: Some(Id::new(7)),
+            verified_roles: vec![Id::new(8), Id::new(9)],
+            logs: Some(Id::new(10)),
         },
     };
 
     assert_tokens(
         &guild,
         &[
-            Token::Struct {
-                name: "Guild",
-                len: 2,
-            },
+            Token::Map { len: None },
             Token::Str("_id"),
             Token::I64(1),
-            Token::Str("config"),
-            Token::Map { len: None },
             Token::Str("logs_chan"),
             Token::Some,
             Token::I64(2),
-            Token::Str("moderator_roles"),
+            Token::Str("moderation_roles"),
             Token::Seq { len: Some(2) },
             Token::I64(3),
             Token::I64(4),
             Token::SeqEnd,
-            Token::Str("enforce_reason"),
+            Token::Str("moderation_enforce_reason"),
             Token::Bool(true),
-            Token::Str("anonymize_moderator"),
+            Token::Str("moderation_anonymize"),
             Token::Bool(false),
             Token::Str("captcha_enabled"),
             Token::Bool(true),
-            Token::Str("captcha_verification_channel"),
+            Token::Str("captcha_channel"),
             Token::Some,
             Token::I64(5),
-            Token::Str("captcha_verification_message"),
+            Token::Str("captcha_message"),
             Token::Some,
             Token::I64(6),
-            Token::Str("captcha_unverified_role"),
+            Token::Str("captcha_role"),
             Token::Some,
             Token::I64(7),
             Token::Str("captcha_verified_roles"),
@@ -90,11 +81,10 @@ fn test_guild_full() {
             Token::I64(8),
             Token::I64(9),
             Token::SeqEnd,
-            Token::Str("captcha_logs_channel"),
+            Token::Str("captcha_logs"),
             Token::Some,
             Token::I64(10),
             Token::MapEnd,
-            Token::StructEnd,
         ],
     );
 }
@@ -103,36 +93,34 @@ fn test_guild_full() {
 fn test_guild_bson() {
     let guild = Guild {
         id: Id::new(1),
-        config: Config {
-            logs_chan: Some(Id::new(2)),
-            moderator_roles: vec![Id::new(3), Id::new(4)],
+        logs_chan: Some(Id::new(2)),
+        moderation: Moderation {
+            roles: vec![Id::new(3), Id::new(4)],
             enforce_reason: true,
-            anonymize_moderator: false,
-            captcha: Captcha {
-                enabled: true,
-                verification_channel: Some(Id::new(5)),
-                verification_message: Some(Id::new(6)),
-                unverified_role: Some(Id::new(7)),
-                verified_roles: vec![Id::new(8), Id::new(9)],
-                logs_channel: Some(Id::new(10)),
-            },
+            anonymize: false,
+        },
+        captcha: Captcha {
+            enabled: true,
+            channel: Some(Id::new(5)),
+            message: Some(Id::new(6)),
+            role: Some(Id::new(7)),
+            verified_roles: vec![Id::new(8), Id::new(9)],
+            logs: Some(Id::new(10)),
         },
     };
 
     let expected = bson::doc! {
         "_id": 1_i64,
-        "config": {
-            "logs_chan": 2_i64,
-            "moderator_roles": [3_i64, 4_i64],
-            "enforce_reason": true,
-            "anonymize_moderator": false,
-            "captcha_enabled": true,
-            "captcha_verification_channel": 5_i64,
-            "captcha_verification_message": 6_i64,
-            "captcha_unverified_role": 7_i64,
-            "captcha_verified_roles": [8_i64, 9_i64],
-            "captcha_logs_channel": 10_i64,
-        }
+        "logs_chan": 2_i64,
+        "moderation_roles": [3_i64, 4_i64],
+        "moderation_enforce_reason": true,
+        "moderation_anonymize": false,
+        "captcha_enabled": true,
+        "captcha_channel": 5_i64,
+        "captcha_message": 6_i64,
+        "captcha_role": 7_i64,
+        "captcha_verified_roles": [8_i64, 9_i64],
+        "captcha_logs": 10_i64,
     };
 
     assert_eq!(bson::to_document(&guild).unwrap(), expected);

--- a/raidprotect/src/interaction/command/moderation/kick.rs
+++ b/raidprotect/src/interaction/command/moderation/kick.rs
@@ -104,7 +104,7 @@ impl KickCommand {
             .mongodb()
             .get_guild_or_create(guild.id)
             .await?
-            .config
+            .moderation
             .enforce_reason;
 
         match self.reason {

--- a/raidprotect/src/util/logs_channel.rs
+++ b/raidprotect/src/util/logs_channel.rs
@@ -124,7 +124,7 @@ async fn create_logs_channel(
 
     // Update channel in configuration
     let mut guild = state.mongodb().get_guild_or_create(guild_id).await?;
-    guild.config.logs_chan = Some(logs_channel_id);
+    guild.logs_chan = Some(logs_channel_id);
     state.mongodb().update_guild(&guild).await?;
 
     tx.send(logs_channel_id).ok();


### PR DESCRIPTION
Refactor the `Guild` configuration model:
- Remove the `Config` struct and move its field into `Guild`.
- Use a struct for moderation config, similar to the captcha configuration (#118).
- The bson representation is flattened with prefixes for each struct.