### PR TITLE
refactor(interaction): component handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,15 +1319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,7 +1644,6 @@ dependencies = [
  "async-trait",
  "futures",
  "linkify",
- "nanoid",
  "once_cell",
  "raidprotect-model",
  "rosetta-build",

--- a/model/src/cache/model/interaction.rs
+++ b/model/src/cache/model/interaction.rs
@@ -4,92 +4,65 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use twilight_model::{
     http::interaction::InteractionResponseData,
-    id::{marker::UserMarker, Id},
+    id::{
+        marker::{InteractionMarker, UserMarker},
+        Id,
+    },
     user::User,
 };
 
 use crate::{cache::RedisModel, mongodb::modlog::ModlogType, serde::IdAsU64};
 
-/// State of a component (button, select modal) waiting for user interaction.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum PendingComponent {
-    PostInChat(PostInChatButton),
-}
-
-impl PendingComponent {
-    /// Get the component unique identifier.
-    pub fn id(&self) -> &str {
-        match self {
-            Self::PostInChat(component) => &component.id,
-        }
-    }
-}
-
-impl RedisModel for PendingComponent {
-    type Id = str;
-
-    // Pending components expires after 5 minutes
-    const EXPIRES_AFTER: Option<usize> = Some(5 * 60);
-
-    fn key(&self) -> String {
-        Self::key_from(self.id())
-    }
-
-    fn key_from(id: &Self::Id) -> String {
-        format!("pending:component:{id}")
-    }
-}
-
 /// State for the "post in chat" button.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PostInChatButton {
-    /// Component unique identifier.
-    pub id: String,
     /// Response to send to the channel.
     pub response: InteractionResponseData,
+    /// Initial interaction ID.
+    pub interaction_id: Id<InteractionMarker>,
     /// Id of the initial interaction author.
     #[serde_as(as = "IdAsU64")]
     pub author_id: Id<UserMarker>,
 }
 
-// State of a modal waiting for user interaction.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum PendingModal {
-    Sanction(PendingSanction),
-}
-
-impl PendingModal {
-    /// Get the component unique identifier.
-    pub fn id(&self) -> &str {
-        match self {
-            Self::Sanction(component) => &component.id,
-        }
-    }
-}
-
-impl RedisModel for PendingModal {
+impl RedisModel for PostInChatButton {
     type Id = str;
 
-    // Pending modals expires after 5 minutes
+    // Post in chat buttons expires after 5 minutes
     const EXPIRES_AFTER: Option<usize> = Some(5 * 60);
 
     fn key(&self) -> String {
-        Self::key_from(self.id())
+        Self::key_from(&self.interaction_id.to_string())
     }
 
     fn key_from(id: &Self::Id) -> String {
-        format!("pending:modal:{id}")
+        format!("pending:post-in-chat:{id}")
     }
 }
 
 /// State for a pending sanction modal.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingSanction {
-    /// Component unique identifier.
-    pub id: String,
+    /// Initial interaction ID.
+    pub interaction_id: Id<InteractionMarker>,
     /// Type of the pending modlog.
     pub kind: ModlogType,
     /// User targeted by the sanction.
     pub user: User,
+}
+
+impl RedisModel for PendingSanction {
+    type Id = str;
+
+    // Pending modals expires after 5 minutes
+    const EXPIRES_AFTER: Option<usize> = Some(5 * 60);
+
+    fn key(&self) -> String {
+        Self::key_from(&self.interaction_id.to_string())
+    }
+
+    fn key_from(id: &Self::Id) -> String {
+        format!("pending:sanction:{id}")
+    }
 }

--- a/raidprotect/Cargo.toml
+++ b/raidprotect/Cargo.toml
@@ -12,7 +12,6 @@ raidprotect-model = { path = "../model" }
 
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 async-trait = "0.1.56"
-nanoid = "0.4.0"
 once_cell = "1.13.0"
 rosetta-i18n = "0.1.2"
 

--- a/raidprotect/src/interaction/command/moderation/kick.rs
+++ b/raidprotect/src/interaction/command/moderation/kick.rs
@@ -24,7 +24,11 @@ use twilight_model::{
 use crate::{
     cluster::ClusterState,
     desc_localizations, impl_command_handle,
-    interaction::{embed, response::InteractionResponse, util::InteractionExt},
+    interaction::{
+        embed,
+        response::InteractionResponse,
+        util::{CustomId, InteractionExt},
+    },
     translations::Lang,
     util::TextProcessExt,
 };
@@ -154,7 +158,7 @@ impl KickCommand {
         ];
 
         // Add pending component in Redis
-        let custom_id = format!("sanction:{}", interaction_id);
+        let custom_id = CustomId::new("sanction", interaction_id.to_string());
         let pending = PendingSanction {
             interaction_id,
             kind: ModlogType::Kick,
@@ -164,7 +168,7 @@ impl KickCommand {
         state.redis().set(&pending).await?;
 
         Ok(InteractionResponse::Modal {
-            custom_id,
+            custom_id: custom_id.to_string(),
             title: lang.modal_kick_title(username),
             components,
         })

--- a/raidprotect/src/interaction/command/profile.rs
+++ b/raidprotect/src/interaction/command/profile.rs
@@ -106,6 +106,6 @@ impl ProfileCommand {
             .build();
         let author_id = interaction.author_id().context("missing author id")?;
 
-        PostInChat::create(response, author_id, state, lang).await
+        PostInChat::create(response, interaction.id, author_id, state, lang).await
     }
 }

--- a/raidprotect/src/interaction/handle.rs
+++ b/raidprotect/src/interaction/handle.rs
@@ -85,7 +85,7 @@ async fn handle_component(
 
     let (name, component_id) = match custom_id.split_once(':') {
         Some((name, id)) => (name, id),
-        None => bail!("expected custom_id to contain ':'"),
+        None => (&*custom_id, ""),
     };
 
     match name {
@@ -110,7 +110,7 @@ async fn handle_modal(
 
     let (name, _modal_id) = match custom_id.split_once(':') {
         Some((name, id)) => (name, id),
-        None => bail!("expected custom_id to contain ':'"),
+        None => (&*custom_id, ""),
     };
 
     match name {

--- a/raidprotect/src/interaction/util.rs
+++ b/raidprotect/src/interaction/util.rs
@@ -1,5 +1,9 @@
 //! Utility function to handle incoming interactions.
-use std::mem;
+use std::{
+    fmt::{self, Display},
+    mem,
+    str::FromStr,
+};
 
 use anyhow::{bail, Context};
 use twilight_interactions::command::CommandModel;
@@ -47,6 +51,61 @@ pub struct GuildInteraction<'a> {
     pub id: Id<GuildMarker>,
     /// The member that triggered the command.
     pub member: &'a PartialMember,
+}
+
+/// Component custom id.
+///
+/// This type is used to hold component identifiers, used in buttons or modals.
+/// Each custom id must have a `name` which correspond to the component type,
+/// and optionally an `id` used to store component state.
+pub struct CustomId {
+    /// Name of the component.
+    pub name: String,
+    /// ID of the component.
+    pub id: Option<String>,
+}
+
+impl CustomId {
+    /// Create a new custom id.
+    pub fn new(name: impl Into<String>, id: String) -> Self {
+        Self {
+            name: name.into(),
+            id: Some(id),
+        }
+    }
+}
+
+impl FromStr for CustomId {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() {
+            bail!("expected non-empty custom id");
+        }
+
+        match value.split_once(':') {
+            Some((name, id)) => Ok(CustomId {
+                name: name.to_string(),
+                id: Some(id.to_string()),
+            }),
+            None => Ok(CustomId {
+                name: value.to_string(),
+                id: None,
+            }),
+        }
+    }
+}
+
+impl Display for CustomId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(id) = &self.id {
+            f.write_str(&self.name)?;
+            f.write_str(":")?;
+            f.write_str(id)
+        } else {
+            f.write_str(&self.name)
+        }
+    }
 }
 
 /// Parse incoming [`ApplicationCommand`] or [`ApplicationCommandAutocomplete`]


### PR DESCRIPTION
Refactor how the bot handle incoming components.

The previous version stored all pending components in Redis. Since some components have no state, this PR parse the component `custom_id` instead and let the called component implementation retrieve state from Redis if required.

The `custom_id` format is now the following: `name` or `name:id`, where *name* is the name of the called component type, and *id* an optional id attached to it and used to retrieve state.
