### PR TITLE
feat: use localazy for translations

### DIFF
--- a/.github/workflows/localazy-download.yml
+++ b/.github/workflows/localazy-download.yml
@@ -1,0 +1,36 @@
+name: Download from Localazy
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+
+jobs:
+  localazy-download:
+    name: Upload from Localazy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Download localization files
+        uses: localazy/download@v1
+        with:
+          read_key: ${{ secrets.LOCALAZY_READ_KEY }}
+          write_key: ${{ secrets.LOCALAZY_WRITE_KEY }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: localazy/download-translations
+          commit-message: Update translations from Localazy
+          title: 'chore: update translations'
+          body: |
+            Update translations from the [RaidProtect Project on Localazy][1].
+
+            *This pull request will be updated daily at 06:00 UTC.*
+
+            [1]: https://localazy.com/p/raidprotect-bot/
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/localazy-upload.yml
+++ b/.github/workflows/localazy-upload.yml
@@ -1,0 +1,20 @@
+name: Upload to Localazy
+on:
+  push:
+    branches: ["main"]
+    paths: ["raidprotect/locales/*.json"]
+
+jobs:
+  localazy-upload:
+    name: Upload to Localazy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Upload localization files
+        uses: localazy/upload@v1
+        with:
+          read_key: ${{ secrets.LOCALAZY_READ_KEY }}
+          write_key: ${{ secrets.LOCALAZY_WRITE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /log
 .env
+localazy.keys.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
     "i18n-ally.localesPaths": [
         "raidprotect/locales"
     ],
-    "i18n-ally.sourceLanguage": "en",
+    "i18n-ally.sourceLanguage": "fr",
     "i18n-ally.keystyle": "flat",
     "i18n-ally.indent": 4,
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,14 @@ Pull request titles should follow the
 
 Once your PR has been opened, please remain available if we need to ask for
 changes. Thank you for your contribution! 🎉
+
+## Localization
+
+This project rely on Localazy to manage translations. If you want to help,
+join the [project on Localazy](https://localazy.com/p/raidprotect-bot).
+
+Since the maintainers are not native English speakers, the fallback languages
+is set to French, which means that all strings must be translated in French for
+the code to compile. If you want to do a contribution which implies **adding a
+localized string**, use a web translator for the French translation and let us
+know in the PR. We will review the translation and fix it if needed.

--- a/localazy.json
+++ b/localazy.json
@@ -6,8 +6,7 @@
         "pattern": "raidprotect/locales/*.json",
         "lang": "${autodetectLang}"
       },
-      "deprecate": "file",
-      "importAsNew": true
+      "deprecate": "file"
     },
 
     "download": {

--- a/localazy.json
+++ b/localazy.json
@@ -1,0 +1,16 @@
+{
+    "upload": {
+      "type": "json",
+      "features": ["filter_untranslated"],
+      "files": {
+        "pattern": "raidprotect/locales/*.json",
+        "lang": "${autodetectLang}"
+      },
+      "deprecate": "file",
+      "importAsNew": true
+    },
+
+    "download": {
+      "files": "raidprotect/locales/${lang}.json"
+    }
+  }

--- a/raidprotect/build.rs
+++ b/raidprotect/build.rs
@@ -2,7 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rosetta_build::config()
         .source("fr", "./locales/fr.json")
         .source("en", "./locales/en.json")
-        .fallback("en")
+        .fallback("fr")
         .generate()?;
 
     Ok(())

--- a/raidprotect/src/event/message/handle.rs
+++ b/raidprotect/src/event/message/handle.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
 use once_cell::sync::Lazy;
-use rosetta_i18n::Language;
 use tracing::{error, info};
 use twilight_model::channel::Message;
 use twilight_util::builder::embed::EmbedBuilder;
@@ -51,7 +50,7 @@ async fn warn_old_command(message: Message, state: Arc<ClusterState>) {
         .author
         .locale
         .map(|locale| Lang::from(locale.as_str()))
-        .unwrap_or_else(Lang::fallback);
+        .unwrap_or(Lang::DEFAULT);
 
     let (old_cmd, new_cmd) = match OLD_COMMANDS
         .iter()

--- a/raidprotect/src/interaction/embed/error.rs
+++ b/raidprotect/src/interaction/embed/error.rs
@@ -42,22 +42,20 @@ pub fn expired_interaction(lang: Lang) -> InteractionResponse {
 
 #[cfg(test)]
 mod tests {
-    use rosetta_i18n::Language;
-
     use super::*;
 
     #[test]
     fn test_internal_error() {
-        internal_error(Lang::fallback());
+        internal_error(Lang::DEFAULT);
     }
 
     #[test]
     fn test_unknown_command() {
-        unknown_command(Lang::fallback());
+        unknown_command(Lang::DEFAULT);
     }
 
     #[test]
     fn test_expired_component() {
-        expired_interaction(Lang::fallback());
+        expired_interaction(Lang::DEFAULT);
     }
 }

--- a/raidprotect/src/interaction/embed/kick.rs
+++ b/raidprotect/src/interaction/embed/kick.rs
@@ -61,32 +61,30 @@ pub fn member_owner(lang: Lang) -> InteractionResponse {
 
 #[cfg(test)]
 mod tests {
-    use rosetta_i18n::Language;
-
     use super::*;
 
     #[test]
     fn test_not_member() {
-        not_member("test".to_string(), Lang::fallback());
+        not_member("test".to_string(), Lang::DEFAULT);
     }
 
     #[test]
     fn test_bot_missing_permission() {
-        bot_missing_permission(Lang::fallback());
+        bot_missing_permission(Lang::DEFAULT);
     }
 
     #[test]
     fn test_user_hierarchy() {
-        user_hierarchy(Lang::fallback());
+        user_hierarchy(Lang::DEFAULT);
     }
 
     #[test]
     fn test_bot_hierarchy() {
-        bot_hierarchy(Lang::fallback());
+        bot_hierarchy(Lang::DEFAULT);
     }
 
     #[test]
     fn test_member_owner() {
-        member_owner(Lang::fallback());
+        member_owner(Lang::DEFAULT);
     }
 }

--- a/raidprotect/src/interaction/handle.rs
+++ b/raidprotect/src/interaction/handle.rs
@@ -1,7 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
 use anyhow::bail;
-use rosetta_i18n::Language;
 use tracing::{debug, error, warn};
 use twilight_interactions::command::CreateCommand;
 use twilight_model::{
@@ -28,7 +27,7 @@ pub async fn handle_interaction(interaction: Interaction, state: Arc<ClusterStat
     let responder = InteractionResponder::from_interaction(&interaction);
     debug!(id = ?interaction.id, "received {} interaction", interaction.kind.kind());
 
-    let lang = interaction.locale().unwrap_or_else(|_| Lang::fallback());
+    let lang = interaction.locale().unwrap_or(Lang::DEFAULT);
 
     let response = match interaction.kind {
         InteractionType::ApplicationCommand => handle_command(interaction, &state).await,

--- a/raidprotect/src/main.rs
+++ b/raidprotect/src/main.rs
@@ -59,9 +59,12 @@ mod translations {
     //!
     //! [Discord Docs/Locales]: https://discord.com/developers/docs/reference#locales
 
-    use rosetta_i18n::Language;
-
     rosetta_i18n::include_translations!();
+
+    impl Lang {
+        /// Default language used when the user language is not supported.
+        pub const DEFAULT: Self = Self::En;
+    }
 
     impl From<&str> for Lang {
         fn from(value: &str) -> Self {
@@ -73,7 +76,7 @@ mod translations {
             match lang {
                 "fr" => Lang::Fr,
                 "en" => Lang::En,
-                _ => Lang::fallback(),
+                _ => Lang::DEFAULT,
             }
         }
     }


### PR DESCRIPTION
Use Localazy to manage the bot translations: https://localazy.com/p/raidprotect-bot/

This PR also changes the default language to French, since this would allow reviewing English translations in Localazy (I'm not a native English speaker, so English translations may be incorrect). 