### PR TITLE
feat: configure permissions for captcha role

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,4 @@
     ],
     "i18n-ally.sourceLanguage": "fr",
     "i18n-ally.keystyle": "flat",
-    "i18n-ally.indent": 4,
 }

--- a/model/src/cache/http.rs
+++ b/model/src/cache/http.rs
@@ -100,6 +100,13 @@ impl<'a> CacheHttp<'a> {
         Ok(self.http.create_guild_channel(self.guild_id, name)?)
     }
 
+    /// Update a channel's permission overwrite.
+    ///
+    /// This method ensures that the bot has the [`MANAGE_ROLES`] and
+    /// [`MANAGE_CHANNELS`] permission.
+    ///
+    /// [`MANAGE_ROLES`]: Permissions::MANAGE_ROLES
+    /// [`MANAGE_CHANNELS`]: Permissions::MANAGE_CHANNELS
     pub async fn update_channel_permission(
         &'a self,
         channel_id: Id<ChannelMarker>,
@@ -113,7 +120,7 @@ impl<'a> CacheHttp<'a> {
             .await?
             .guild();
 
-        if !permissions.contains(Permissions::MANAGE_CHANNELS) {
+        if !permissions.contains(Permissions::MANAGE_ROLES | Permissions::MANAGE_CHANNELS) {
             return Err(anyhow!("missing permissions to update channel permissions"));
         }
 

--- a/raidprotect/locales/fr.json
+++ b/raidprotect/locales/fr.json
@@ -82,5 +82,5 @@
   "unknown_command_title": "Cette commande n'est pas encore disponible",
   "warning_deprecated_command_description": "Utilisez la nouvelle commande `{new_command}` à la place de `{old_command}`.\n\nSi vous n'avez jamais utilisé les commandes slash, [lisez la FAQ](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ).",
   "warning_deprecated_command_title": "RaidProtect supporte désormais les commandes slash",
-  "captcha_enabled_log": "Le captcha a été activé sur le serveur par {user}."
+  "captcha_enabled_log": "**Le captcha a été activé** sur le serveur par {user}."
 }

--- a/raidprotect/locales/fr.json
+++ b/raidprotect/locales/fr.json
@@ -23,7 +23,7 @@
   "captcha_disable_description": "Désactiver le captcha RaidProtect",
   "captcha_enable_description": "Activer le captcha RaidProtect",
   "captcha_enable_reason": "Activation du captcha",
-  "captcha_enabled_description": "Les nouveaux membres devront désormais passer une vérification afin d'accéder à ce serveur. Le salon {channel} et le rôle {role} ont été créés et configurés automatiquement.\n\nRaidProtect est en train de masquer vos salons aux membres n'ayant pas passé la vérification. Ce processus peut prendre une dizaine de minutes en fonction du nombre de salons que vous avez.",
+  "captcha_enabled_description": "Les nouveaux membres devront désormais passer une vérification afin d'accéder à ce serveur. Le salon {channel} et le rôle {role} ont été créés et configurés automatiquement.\n\nRaidProtect est en train de masquer vos salons aux membres n'ayant pas passé la vérification. Tout sera fonctionnel d'ici quelques minutes !",
   "captcha_enabled_rename_description": "Vous pouvez sans problème renommer le rôle {role} et le salon {channel} si leurs noms ne vous conviennent pas. Attention à ne pas modifier leurs permissions, le captcha risque de ne plus fonctionner.",
   "captcha_enabled_rename_title": "Renommage du rôle et du salon",
   "captcha_enabled_roles_description": "Par défaut, les membres ne recevront aucun rôle après avoir passé la vérification. Vous pouvez ajouter un rôle à donner automatiquement avec la commande `/config captcha autorole-add`. \n\n**Si vous avez déjà un bot qui donne automatiquement un rôle à tous les nouveaux membres** (autorole), désactivez-le et utilisez la fonctionnalité du captcha décrite ci-dessus. Les autres bots risquent d'interférer avec le captcha.",
@@ -81,5 +81,6 @@
   "unknown_command_description": "La commande que vous essayez d'effectuer n'est pas encore disponible. Patientez quelques minutes et réessayez.",
   "unknown_command_title": "Cette commande n'est pas encore disponible",
   "warning_deprecated_command_description": "Utilisez la nouvelle commande `{new_command}` à la place de `{old_command}`.\n\nSi vous n'avez jamais utilisé les commandes slash, [lisez la FAQ](https://support.discord.com/hc/en-us/articles/1500000368501-Slash-Commands-FAQ).",
-  "warning_deprecated_command_title": "RaidProtect supporte désormais les commandes slash"
+  "warning_deprecated_command_title": "RaidProtect supporte désormais les commandes slash",
+  "captcha_enabled_log": "Le captcha a été activé sur le serveur par {user}."
 }

--- a/raidprotect/src/interaction/component/captcha/enable.rs
+++ b/raidprotect/src/interaction/component/captcha/enable.rs
@@ -259,7 +259,7 @@ async fn logs_message(
     user: Id<UserMarker>,
     lang: Lang,
 ) -> Result<(), anyhow::Error> {
-    let channel = guild_logs_channel(state.clone(), guild, logs_channel, lang).await?;
+    let channel = guild_logs_channel(&state, guild, logs_channel, lang).await?;
 
     let embed = EmbedBuilder::new()
         .color(COLOR_RED)

--- a/raidprotect/src/interaction/component/captcha/enable.rs
+++ b/raidprotect/src/interaction/component/captcha/enable.rs
@@ -1,8 +1,10 @@
 //! Captcha button components.
 
+use std::{sync::Arc, time::Duration};
+
 use anyhow::Context;
-use raidprotect_model::cache::model::CachedGuild;
-use tracing::error;
+use raidprotect_model::cache::model::{CachedChannel, CachedGuild};
+use tracing::{debug, error};
 use twilight_http::request::AuditLogReason;
 use twilight_mention::Mention;
 use twilight_model::{
@@ -15,6 +17,14 @@ use twilight_model::{
         ChannelType,
     },
     guild::Permissions,
+    http::permission_overwrite::{
+        PermissionOverwrite as HttpPermissionOverwrite,
+        PermissionOverwriteType as HttpPermissionOverwriteType,
+    },
+    id::{
+        marker::{ChannelMarker, GuildMarker, RoleMarker},
+        Id,
+    },
 };
 use twilight_util::builder::embed::{EmbedBuilder, EmbedFieldBuilder};
 
@@ -45,7 +55,7 @@ pub struct CaptchaEnable;
 impl CaptchaEnable {
     pub async fn handle(
         interaction: Interaction,
-        state: &ClusterState,
+        state: Arc<ClusterState>,
     ) -> Result<InteractionResponse, anyhow::Error> {
         let guild = interaction.guild()?;
         let cached_guild = state
@@ -184,6 +194,12 @@ impl CaptchaEnable {
         state.mongodb().update_guild(&config).await?;
 
         // Start the configuration of channels permissions.
+        tokio::spawn(configure_channels(
+            state,
+            guild.id,
+            unverified_role.id,
+            verification_channel.id,
+        ));
 
         // Send the confirmation message.
         let embed = EmbedBuilder::new()
@@ -208,4 +224,124 @@ impl CaptchaEnable {
 
         Ok(InteractionResponse::EphemeralEmbed(embed))
     }
+}
+
+/// Configure the permissions of the guild channels.
+///
+/// For the unverified role to work, all the channels of the guild must be
+/// hidden to the role. This function should be used as a background task.
+///
+/// The function will iterate over all guilds channels and compute permissions
+/// for the unverified role. If the role can see the channel, the permissions
+/// will be updated accordingly (see [`update_channel_permissions`]).
+///
+/// The category channels are iterated first, since a lot of channels can inherit
+/// from their permissions. The verification channel is skipped.
+async fn configure_channels(
+    state: Arc<ClusterState>,
+    guild: Id<GuildMarker>,
+    role: Id<RoleMarker>,
+    verification: Id<ChannelMarker>,
+) -> Result<(), anyhow::Error> {
+    let guild_channels = state.redis().guild_channels(guild).await?;
+
+    let mut categories = Vec::new();
+    let mut channels = Vec::new();
+
+    for channel in guild_channels {
+        // Permissions are not updated for the verification channel.
+        if channel.id() == verification {
+            continue;
+        }
+
+        match channel {
+            CachedChannel::Category(_) => categories.push(channel),
+            CachedChannel::Text(channel) => channels.push(channel.id),
+            CachedChannel::Voice(channel) => channels.push(channel.id),
+            CachedChannel::Thread(_) => continue, // threads inherit from their parent channel
+        }
+    }
+
+    // Update permissions for the category channels first.
+    // This will reduce the number of requests to the API since a lot of channels
+    // can inherit from their category.
+    for channel in categories {
+        update_channel_permissions(&state, &channel, guild, role).await?;
+    }
+
+    // Small delay to ensure the cache is updated with the new permissions.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Update permissions for the remaining channels.
+    // Since the permissions for these channels could have been updated by the
+    // category channels, the channel is retrieved from the cache again.
+    for channel in channels {
+        let channel = match state.redis().get::<CachedChannel>(&channel).await? {
+            Some(channel) => channel,
+            None => {
+                // Since some delay could have been elapsed since the previous
+                // cache request, the channel could have been deleted.
+                debug!(channel = ?channel, guild = ?guild, "channel no longer in cache during captcha configuration");
+
+                continue;
+            }
+        };
+
+        update_channel_permissions(&state, &channel, guild, role).await?;
+    }
+
+    Ok(())
+}
+
+/// Updates a channel permissions for the unverified role.
+async fn update_channel_permissions(
+    state: &ClusterState,
+    channel: &CachedChannel,
+    guild: Id<GuildMarker>,
+    role: Id<RoleMarker>,
+) -> Result<(), anyhow::Error> {
+    // Get permissions for the unverified role. The permissions for everyone
+    // are also retrieved to avoid updating permissions unnecessarily for private
+    // channels.
+    let role_permissions = channel.permissions().iter().find(|p| p.id == role.cast());
+    let everyone_permissions = channel.permissions().iter().find(|p| p.id == guild.cast());
+
+    // Skip updating permissions if the channel is private.
+    if everyone_permissions
+        .map(|p| p.deny)
+        .unwrap_or(Permissions::empty())
+        .contains(Permissions::VIEW_CHANNEL)
+    {
+        return Ok(());
+    }
+
+    // Skip updating permissions if the role is already denied to view the channel.
+    // This will be the case if the channel is a text channel that inherits from
+    // a category channel (that should have been updated first).
+    if role_permissions
+        .map(|p| p.deny)
+        .unwrap_or(Permissions::empty())
+        .contains(Permissions::VIEW_CHANNEL)
+    {
+        return Ok(());
+    }
+
+    // Update the permissions for the unverified role.
+    let permission_overwrite = HttpPermissionOverwrite {
+        id: role.cast(),
+        kind: HttpPermissionOverwriteType::Role,
+        allow: None,
+        deny: Some(Permissions::VIEW_CHANNEL),
+    };
+
+    if let Err(error) = state
+        .http()
+        .update_channel_permission(channel.id(), &permission_overwrite)
+        .exec()
+        .await
+    {
+        error!(error = ?error, "failed to update channel permissions for unverified role");
+    }
+
+    Ok(())
 }

--- a/raidprotect/src/interaction/handle.rs
+++ b/raidprotect/src/interaction/handle.rs
@@ -30,9 +30,9 @@ pub async fn handle_interaction(interaction: Interaction, state: Arc<ClusterStat
     let lang = interaction.locale().unwrap_or(Lang::DEFAULT);
 
     let response = match interaction.kind {
-        InteractionType::ApplicationCommand => handle_command(interaction, &state).await,
-        InteractionType::MessageComponent => handle_component(interaction, &state).await,
-        InteractionType::ModalSubmit => handle_modal(interaction, &state).await,
+        InteractionType::ApplicationCommand => handle_command(interaction, state.clone()).await,
+        InteractionType::MessageComponent => handle_component(interaction, state.clone()).await,
+        InteractionType::ModalSubmit => handle_modal(interaction, state.clone()).await,
         other => {
             warn!("received unexpected {} interaction", other.kind());
 
@@ -55,7 +55,7 @@ pub async fn handle_interaction(interaction: Interaction, state: Arc<ClusterStat
 /// Handle incoming command interaction.
 async fn handle_command(
     interaction: Interaction,
-    state: &ClusterState,
+    state: Arc<ClusterState>,
 ) -> Result<InteractionResponse, anyhow::Error> {
     let name = match &interaction.data {
         Some(InteractionData::ApplicationCommand(data)) => &*data.name,
@@ -63,10 +63,10 @@ async fn handle_command(
     };
 
     match name {
-        "config" => ConfigCommand::handle(interaction, state).await,
-        "help" => HelpCommand::handle(interaction, state).await,
-        "kick" => KickCommand::handle(interaction, state).await,
-        "profile" => ProfileCommand::handle(interaction, state).await,
+        "config" => ConfigCommand::handle(interaction, &state).await,
+        "help" => HelpCommand::handle(interaction, &state).await,
+        "kick" => KickCommand::handle(interaction, &state).await,
+        "profile" => ProfileCommand::handle(interaction, &state).await,
         name => {
             warn!(name = name, "received unknown command");
 
@@ -78,7 +78,7 @@ async fn handle_command(
 /// Handle incoming component interaction
 async fn handle_component(
     interaction: Interaction,
-    state: &ClusterState,
+    state: Arc<ClusterState>,
 ) -> Result<InteractionResponse, anyhow::Error> {
     let custom_id = match &interaction.data {
         Some(InteractionData::MessageComponent(data)) => CustomId::from_str(&*data.custom_id)?,
@@ -86,7 +86,7 @@ async fn handle_component(
     };
 
     match &*custom_id.name {
-        "post-in-chat" => PostInChat::handle(interaction, custom_id, state).await,
+        "post-in-chat" => PostInChat::handle(interaction, custom_id, &state).await,
         "captcha-enable" => CaptchaEnable::handle(interaction, state).await,
         "captcha-disable" => todo!(),
         name => {
@@ -100,7 +100,7 @@ async fn handle_component(
 /// Handle incoming modal interaction
 async fn handle_modal(
     interaction: Interaction,
-    _state: &ClusterState,
+    _state: Arc<ClusterState>,
 ) -> Result<InteractionResponse, anyhow::Error> {
     let custom_id = match &interaction.data {
         Some(InteractionData::ModalSubmit(data)) => CustomId::from_str(&*data.custom_id)?,

--- a/raidprotect/src/util/logs_channel.rs
+++ b/raidprotect/src/util/logs_channel.rs
@@ -9,15 +9,13 @@
 //! A simple locking mechanism is used to prevent multiple channels to be created
 //! at the same time.
 
-#![allow(unused)]
+use std::{collections::HashMap, sync::Arc};
 
-use std::collections::HashMap;
-
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use once_cell::sync::Lazy;
-use raidprotect_model::{cache::model::CachedChannel, mongodb::MongoDbError};
+use raidprotect_model::cache::model::CachedChannel;
 use tokio::sync::{broadcast, RwLock};
-use twilight_http::{error::Error as HttpError, response::DeserializeBodyError};
+use tracing::{error, trace};
 use twilight_model::{
     channel::{
         permission_overwrite::{PermissionOverwrite, PermissionOverwriteType},
@@ -51,87 +49,98 @@ static PENDING_CHANNELS: Lazy<RwLock<PendingChannelsMap>> =
 ///
 /// See the [module documentation](super) for more information.
 pub async fn guild_logs_channel(
-    guild_id: Id<GuildMarker>,
-    logs_chan: Option<Id<ChannelMarker>>,
-    state: &ClusterState,
+    state: Arc<ClusterState>,
+    guild: Id<GuildMarker>,
+    logs_channel: Option<Id<ChannelMarker>>,
     lang: Lang,
 ) -> Result<Id<ChannelMarker>, anyhow::Error> {
-    // If a channel is given, ensure the channel exists
-    if let Some(logs_chan) = logs_chan {
-        if state
-            .redis()
-            .get::<CachedChannel>(&logs_chan)
-            .await?
-            .is_some()
-        {
-            return Ok(logs_chan);
+    // If a channel is already configured, ensure it exists and return it.
+    if let Some(channel) = logs_channel {
+        let cached = state.redis().get::<CachedChannel>(&channel).await?;
+
+        if cached.is_some() {
+            return Ok(channel);
         }
     }
 
-    // Create the logs channel
-    if let Some(tx) = PENDING_CHANNELS.read().await.get(&guild_id) {
-        let mut rx = tx.subscribe();
+    // To avoid creating multiple channels, we use the `PENDING_CHANNELS` map to
+    // store a lock for each guild. The lock is a broadcast channel, so we can
+    // send the created channel to all the pending tasks.
+    let receiver = {
+        let pending_channels = PENDING_CHANNELS.read().await;
+        let sender = pending_channels.get(&guild);
+
+        sender.map(|s| s.subscribe())
+    };
+
+    // If a channel is being created, wait and return it's id
+    if let Some(mut rx) = receiver {
+        trace!(guild = ?guild, "waiting for logs channel to be created");
 
         match rx.recv().await {
-            Ok(logs_chan) => Ok(logs_chan),
-            Err(_) => Err(anyhow!("error while waiting for logs channel creation")),
+            Ok(channel) => return Ok(channel),
+            Err(_) => return Err(anyhow!("error while waiting for logs channel creation")),
         }
-    } else {
-        create_logs_channel(guild_id, state, lang).await
     }
+
+    // Create a new logs channel
+    trace!(guild = ?guild, "creating logs channel");
+
+    configure_logs_channel(state, guild, lang).await
 }
 
-/// Create a new logs channel
-async fn create_logs_channel(
-    guild_id: Id<GuildMarker>,
-    state: &ClusterState,
+/// Try to find an existing logs channel, or create a new one.
+async fn configure_logs_channel(
+    state: Arc<ClusterState>,
+    guild: Id<GuildMarker>,
     lang: Lang,
 ) -> Result<Id<ChannelMarker>, anyhow::Error> {
-    let (tx, _) = broadcast::channel(1);
-    PENDING_CHANNELS.write().await.insert(guild_id, tx.clone());
+    // Add a lock to the pending channels map.
+    let sender = {
+        let mut pending_channels = PENDING_CHANNELS.write().await;
+        let (sender, _) = broadcast::channel(1);
 
-    // Check if a channel named `raidprotect-logs` already exists.
-    // If not, create a new channel.
-    let channels = state.redis().guild_channels(guild_id).await?;
-    let logs_channel = channels.iter().find(|channel| match channel {
+        pending_channels.insert(guild, sender.clone());
+
+        sender
+    };
+
+    // Try to find an existing channel .
+    let guild_channels = state.redis().guild_channels(guild).await?;
+    let logs_channel = guild_channels.iter().find(|channel| match channel {
         CachedChannel::Text(channel) => channel.name == DEFAULT_LOGS_NAME,
         _ => false,
     });
 
-    // Create channel if not exists
-    let logs_channel_id = if let Some(channel) = logs_channel {
-        channel.id()
-    } else {
-        // Deny everyone role to see the channel
-        let permission_overwrite = PermissionOverwrite {
-            allow: Permissions::empty(),
-            deny: Permissions::VIEW_CHANNEL,
-            id: guild_id.cast(),
-            kind: PermissionOverwriteType::Role,
-        };
-
-        let channel = state
-            .cache_http(guild_id)
-            .create_guild_channel(DEFAULT_LOGS_NAME)
-            .await?
-            .kind(ChannelType::GuildText)
-            .permission_overwrites(&[permission_overwrite])
-            .exec()
-            .await?
-            .model()
-            .await?;
-
-        channel.id
+    let logs_channel = match logs_channel {
+        Some(channel) => channel.id(),
+        None => create_logs_channel(&state, guild).await?,
     };
 
-    // Update channel in configuration
-    let mut guild = state.mongodb().get_guild_or_create(guild_id).await?;
-    guild.logs_chan = Some(logs_channel_id);
-    state.mongodb().update_guild(&guild).await?;
+    // Update the guild configuration
+    let mut config = state.mongodb().get_guild_or_create(guild).await?;
+    config.logs_chan = Some(logs_channel);
+    state.mongodb().update_guild(&config).await?;
 
-    tx.send(logs_channel_id).ok();
+    // Notify pending tasks that the channel has been created.
+    sender.send(logs_channel).ok();
 
-    // Send message in channel
+    tokio::spawn(async move {
+        if let Err(error) = send_logs_message(state, guild, logs_channel, lang).await {
+            error!(error = ?error, guild = ?guild, "error while sending initial logs channel message");
+        }
+    });
+
+    Ok(logs_channel)
+}
+
+/// Send an informational message to the logs channel.
+async fn send_logs_message(
+    state: Arc<ClusterState>,
+    guild: Id<GuildMarker>,
+    channel: Id<ChannelMarker>,
+    lang: Lang,
+) -> Result<(), anyhow::Error> {
     let embed = EmbedBuilder::new()
         .title(lang.logs_creation_title())
         .color(COLOR_RED)
@@ -139,13 +148,56 @@ async fn create_logs_channel(
         .build();
 
     state
-        .cache_http(guild_id)
-        .create_message(logs_channel_id)
+        .cache_http(guild)
+        .create_message(channel)
         .await?
         .embeds(&[embed])?
         .exec()
-        .await
-        .ok(); // Do not fail if message cannot be sent
+        .await?;
 
-    Ok(logs_channel_id)
+    Ok(())
+}
+
+/// Create a new logs channel in the guild.
+async fn create_logs_channel(
+    state: &ClusterState,
+    guild: Id<GuildMarker>,
+) -> Result<Id<ChannelMarker>, anyhow::Error> {
+    // Hide the channel to the everyone role.
+    // Only users with the `ADMINISTRATOR` permission will be able to see it.
+    let permission_overwrite = [
+        PermissionOverwrite {
+            id: guild.cast(),
+            kind: PermissionOverwriteType::Role,
+            allow: Permissions::empty(),
+            deny: Permissions::VIEW_CHANNEL,
+        },
+        PermissionOverwrite {
+            id: state.current_user().cast(),
+            kind: PermissionOverwriteType::Member,
+            allow: Permissions::VIEW_CHANNEL
+                | Permissions::SEND_MESSAGES
+                | Permissions::EMBED_LINKS,
+            deny: Permissions::empty(),
+        },
+    ];
+
+    let channel = match state
+        .cache_http(guild)
+        .create_guild_channel(DEFAULT_LOGS_NAME)
+        .await?
+        .kind(ChannelType::GuildText)
+        .permission_overwrites(&permission_overwrite)
+        .exec()
+        .await
+    {
+        Ok(response) => response.model().await?,
+        Err(error) => {
+            error!(error = ?error, guild = ?guild, "failed to create logs channel");
+
+            return Err(error).context("failed to create logs channel");
+        }
+    };
+
+    Ok(channel.id)
 }

--- a/raidprotect/src/util/logs_channel.rs
+++ b/raidprotect/src/util/logs_channel.rs
@@ -117,8 +117,8 @@ async fn configure_logs_channel(
     });
 
     let logs_channel = match logs_channel {
-        Some(channel) => update_logs_permissions(&state, channel, guild).await,
-        None => create_logs_channel(&state, guild, lang).await?,
+        Some(channel) => update_logs_permissions(state, channel, guild).await,
+        None => create_logs_channel(state, guild, lang).await?,
     };
 
     // Update the guild configuration


### PR DESCRIPTION
- Automatically configure permission for the unverified role in all guild channels.
- Send a message in the logs channel after the captcha is created.
- Check if the captcha is not already enabled to avoid clicking the button twice.