### PR TITLE
refactor: remove unneeded `ClusterState` methods

### DIFF
--- a/raidprotect/src/cluster.rs
+++ b/raidprotect/src/cluster.rs
@@ -149,58 +149,34 @@ fn presence() -> UpdatePresencePayload {
 
 /// Current state of the cluster.
 ///
-/// This type hold shared types such as the cache or the http client. It does
-/// not implement [`Clone`] and is intended to be wrapped inside a [`Arc`].
-#[derive(Debug)]
+/// This type hold shared types such as the cache or the http client. It implement
+/// [`Clone`] since all underlying types are wrapped in an [`Arc`].
+#[derive(Debug, Clone)]
 pub struct ClusterState {
-    /// In-memory cache
-    redis: CacheClient,
-    /// MongoDB client
-    mongodb: DbClient,
-    /// Http client
-    http: Arc<HttpClient>,
-    /// Bot user id
-    current_user: Id<ApplicationMarker>,
+    pub cache: CacheClient,
+    pub database: DbClient,
+    pub http: Arc<HttpClient>,
+    pub current_user: Id<ApplicationMarker>,
 }
 
 impl ClusterState {
     /// Initialize a new [`ClusterState`].
     pub fn new(
-        redis: CacheClient,
+        cache: CacheClient,
         mongodb: DbClient,
         http: Arc<HttpClient>,
         current_user: Id<ApplicationMarker>,
     ) -> Self {
         Self {
-            redis,
-            mongodb,
+            cache,
+            database: mongodb,
             http,
             current_user,
         }
     }
 
-    /// Get the cluster [`CacheClient`].
-    pub fn redis(&self) -> &CacheClient {
-        &self.redis
-    }
-
-    /// Get the cluster [`DbClient`].
-    pub fn mongodb(&self) -> &DbClient {
-        &self.mongodb
-    }
-
-    /// Get the cluster [`HttpClient`].
-    pub fn http(&self) -> &HttpClient {
-        &self.http
-    }
-
-    /// Get the cluster [`CacheHttp`]
+    /// Get the [`CacheHttp`] client associated with the cache client.
     pub fn cache_http(&self, guild_id: Id<GuildMarker>) -> CacheHttp {
-        self.redis.http(&self.http, guild_id)
-    }
-
-    /// Get the bot user id
-    pub fn current_user(&self) -> Id<ApplicationMarker> {
-        self.current_user
+        self.cache.http(&self.http, guild_id)
     }
 }

--- a/raidprotect/src/cluster.rs
+++ b/raidprotect/src/cluster.rs
@@ -38,7 +38,7 @@ pub struct ShardCluster {
     /// Events stream
     events: Events,
     /// Shared cluster state
-    state: Arc<ClusterState>,
+    state: ClusterState,
 }
 
 impl ShardCluster {
@@ -92,7 +92,7 @@ impl ShardCluster {
         Ok(Self {
             cluster: Arc::new(cluster),
             events,
-            state: Arc::new(state),
+            state,
         })
     }
 

--- a/raidprotect/src/event/message/handle.rs
+++ b/raidprotect/src/event/message/handle.rs
@@ -33,7 +33,7 @@ static OLD_COMMANDS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
 /// modules.
 pub async fn handle_message(message: Message, state: Arc<ClusterState>) {
     let parsed = parse_message(&message);
-    state.redis().set(&parsed).await.ok();
+    state.cache.set(&parsed).await.ok();
 
     if is_old_command(&message.content) {
         let message = message.clone();
@@ -67,7 +67,7 @@ async fn warn_old_command(message: Message, state: Arc<ClusterState>) {
         .build();
 
     match state
-        .http()
+        .http
         .create_message(message.channel_id)
         .reply(message.id)
         .embeds(&[embed])

--- a/raidprotect/src/event/message/handle.rs
+++ b/raidprotect/src/event/message/handle.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use once_cell::sync::Lazy;
 use tracing::{error, info};
@@ -31,7 +31,7 @@ static OLD_COMMANDS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
 ///
 /// This method will forward message to the cache and various auto-moderation
 /// modules.
-pub async fn handle_message(message: Message, state: Arc<ClusterState>) {
+pub async fn handle_message(message: Message, state: &ClusterState) {
     let parsed = parse_message(&message);
     state.cache.set(&parsed).await.ok();
 
@@ -45,7 +45,7 @@ pub async fn handle_message(message: Message, state: Arc<ClusterState>) {
     info!("received message: {}", message.content) // Debug util real implementation
 }
 
-async fn warn_old_command(message: Message, state: Arc<ClusterState>) {
+async fn warn_old_command(message: Message, state: ClusterState) {
     let lang = message
         .author
         .locale

--- a/raidprotect/src/event/process.rs
+++ b/raidprotect/src/event/process.rs
@@ -27,7 +27,7 @@ macro_rules! process_events {
 }
 
 async fn process_cache_event<E: UpdateCache + Debug>(event: E, state: &ClusterState) {
-    if let Err(error) = event.update(state.redis(), state.current_user()).await {
+    if let Err(error) = event.update(&state.cache, state.current_user).await {
         error!(error = ?error, kind = E::NAME, "failed to update cache");
         debug!(event = ?event);
     }

--- a/raidprotect/src/event/process.rs
+++ b/raidprotect/src/event/process.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 use async_trait::async_trait;
 use raidprotect_model::cache::discord::UpdateCache;
@@ -12,7 +12,7 @@ use crate::cluster::ClusterState;
 #[async_trait]
 pub trait ProcessEvent: Sized {
     /// Process incoming event.
-    async fn process(self, state: Arc<ClusterState>);
+    async fn process(self, state: ClusterState);
 }
 
 macro_rules! process_events {
@@ -38,7 +38,7 @@ macro_rules! process_cache_events {
         $(
             #[async_trait]
             impl ProcessEvent for incoming::$event {
-                async fn process(self, state: Arc<ClusterState>) {
+                async fn process(self, state: ClusterState) {
                     process_cache_event(self, &state).await;
                 }
             }
@@ -48,7 +48,7 @@ macro_rules! process_cache_events {
 
 #[async_trait]
 impl ProcessEvent for GatewayEvent {
-    async fn process(self, state: Arc<ClusterState>) {
+    async fn process(self, state: ClusterState) {
         use GatewayEvent::*;
 
         // `self` is renamed `__self` in async_trait macro expansion
@@ -92,24 +92,24 @@ process_cache_events! {
 
 #[async_trait]
 impl ProcessEvent for incoming::InteractionCreate {
-    async fn process(self, state: Arc<ClusterState>) {
-        crate::interaction::handle_interaction(self.0, state).await;
+    async fn process(self, state: ClusterState) {
+        crate::interaction::handle_interaction(self.0, &state).await;
     }
 }
 
 #[async_trait]
 impl ProcessEvent for incoming::MessageCreate {
-    async fn process(self, state: Arc<ClusterState>) {
+    async fn process(self, state: ClusterState) {
         if self.guild_id.is_some() && ALLOWED_MESSAGES_TYPES.contains(&self.kind) {
-            super::message::handle_message(self.0, state).await;
+            super::message::handle_message(self.0, &state).await;
         }
     }
 }
 
 #[async_trait]
 impl ProcessEvent for incoming::MemberAdd {
-    async fn process(self, state: Arc<ClusterState>) {
+    async fn process(self, state: ClusterState) {
         process_cache_event(self.clone(), &state).await;
-        super::captcha::member_add(&self.0, state).await;
+        super::captcha::member_add(&self.0, &state).await;
     }
 }

--- a/raidprotect/src/interaction/command/config/captcha.rs
+++ b/raidprotect/src/interaction/command/config/captcha.rs
@@ -88,7 +88,7 @@ impl CaptchaEnableCommand {
         let lang = interaction.locale()?;
         let guild_id = interaction.guild()?.id;
 
-        let config = state.mongodb().get_guild(guild_id).await?;
+        let config = state.database.get_guild(guild_id).await?;
         let captcha_enabled = config.as_ref().map(|c| c.captcha.enabled).unwrap_or(false);
 
         if captcha_enabled {
@@ -155,7 +155,7 @@ impl CaptchaDisableCommand {
         let lang = interaction.locale()?;
         let guild_id = interaction.guild()?.id;
 
-        let config = state.mongodb().get_guild(guild_id).await?;
+        let config = state.database.get_guild(guild_id).await?;
         let captcha_enabled = config.as_ref().map(|c| c.captcha.enabled).unwrap_or(false);
 
         if !captcha_enabled {
@@ -226,7 +226,7 @@ impl CaptchaLogsCommand {
         let lang = interaction.locale()?;
         let guild_id = interaction.guild()?.id;
 
-        let config = state.mongodb().get_guild(guild_id).await?;
+        let config = state.database.get_guild(guild_id).await?;
         let captcha_enabled = config.as_ref().map(|c| c.captcha.enabled).unwrap_or(false);
 
         if !captcha_enabled {
@@ -235,7 +235,7 @@ impl CaptchaLogsCommand {
 
         // Ensure RaidProtect has permissions to send messages in the channel.
         let (permissions, _) = state
-            .redis()
+            .cache
             .permissions(guild_id)
             .await?
             .current_member()
@@ -251,7 +251,7 @@ impl CaptchaLogsCommand {
         let mut config = config.unwrap(); // SAFETY: `captcha_enabled` is true here
         config.captcha.logs = Some(self.channel);
 
-        state.mongodb().update_guild(&config).await?;
+        state.database.update_guild(&config).await?;
 
         // Send the embed.
         let embed = EmbedBuilder::new()
@@ -286,7 +286,7 @@ impl CaptchaAutoroleAddCommand {
         let lang = interaction.locale()?;
         let guild_id = interaction.guild()?.id;
 
-        let config = state.mongodb().get_guild(guild_id).await?;
+        let config = state.database.get_guild(guild_id).await?;
         let captcha_enabled = config.as_ref().map(|c| c.captcha.enabled).unwrap_or(false);
 
         if !captcha_enabled {
@@ -295,7 +295,7 @@ impl CaptchaAutoroleAddCommand {
 
         // Ensure RaidProtect has permissions to give this role.
         let permissions = state
-            .redis()
+            .cache
             .permissions(guild_id)
             .await?
             .current_member()
@@ -321,7 +321,7 @@ impl CaptchaAutoroleAddCommand {
         }
 
         config.captcha.verified_roles.push(self.role.id);
-        state.mongodb().update_guild(&config).await?;
+        state.database.update_guild(&config).await?;
 
         // Send the embed.
         let embed = EmbedBuilder::new()
@@ -356,7 +356,7 @@ impl CaptchaAutoroleRemoveCommand {
         let lang = interaction.locale()?;
         let guild_id = interaction.guild()?.id;
 
-        let config = state.mongodb().get_guild(guild_id).await?;
+        let config = state.database.get_guild(guild_id).await?;
         let captcha_enabled = config.as_ref().map(|c| c.captcha.enabled).unwrap_or(false);
 
         if !captcha_enabled {
@@ -371,7 +371,7 @@ impl CaptchaAutoroleRemoveCommand {
         }
 
         config.captcha.verified_roles.retain(|r| r != &self.role);
-        state.mongodb().update_guild(&config).await?;
+        state.database.update_guild(&config).await?;
 
         // Send the embed.
         let embed = EmbedBuilder::new()
@@ -403,7 +403,7 @@ impl CaptchaAutoroleListCommand {
         let lang = interaction.locale()?;
         let guild_id = interaction.guild()?.id;
 
-        let config = state.mongodb().get_guild(guild_id).await?;
+        let config = state.database.get_guild(guild_id).await?;
         let captcha_enabled = config.as_ref().map(|c| c.captcha.enabled).unwrap_or(false);
 
         if !captcha_enabled {

--- a/raidprotect/src/interaction/command/moderation/kick.rs
+++ b/raidprotect/src/interaction/command/moderation/kick.rs
@@ -76,7 +76,7 @@ impl KickCommand {
         };
 
         // Fetch the author and the bot permissions.
-        let permissions = state.redis().permissions(guild.id).await?;
+        let permissions = state.cache.permissions(guild.id).await?;
         let author_permissions = permissions.member(author_id, &member.roles).await?;
         let member_permissions = permissions.member(user.id, &member.roles).await?;
         let bot_permissions = permissions.current_member().await?;
@@ -104,7 +104,7 @@ impl KickCommand {
 
         // Send reason modal.
         let enforce_reason = state
-            .mongodb()
+            .database
             .get_guild_or_create(guild.id)
             .await?
             .moderation
@@ -165,7 +165,7 @@ impl KickCommand {
             user,
         };
 
-        state.redis().set(&pending).await?;
+        state.cache.set(&pending).await?;
 
         Ok(InteractionResponse::Modal {
             custom_id: custom_id.to_string(),

--- a/raidprotect/src/interaction/component/captcha/disable.rs
+++ b/raidprotect/src/interaction/component/captcha/disable.rs
@@ -44,7 +44,7 @@ impl CaptchaDisable {
         let lang = interaction.locale()?;
         let author_id = interaction.author_id().context("missing author id")?;
 
-        let mut config = state.mongodb().get_guild_or_create(guild.id).await?;
+        let mut config = state.database.get_guild_or_create(guild.id).await?;
         let guild_lang = Lang::from(&*config.lang);
 
         // Ensure the captcha is enabled.
@@ -55,7 +55,7 @@ impl CaptchaDisable {
         // Try to delete the verification channel and the unverified role.
         if let Some(role) = config.captcha.role {
             if let Err(error) = state
-                .http()
+                .http
                 .delete_role(guild.id, role)
                 .reason(guild_lang.captcha_disable_reason())?
                 .exec()
@@ -67,7 +67,7 @@ impl CaptchaDisable {
 
         if let Some(channel) = config.captcha.channel {
             if let Err(error) = state
-                .http()
+                .http
                 .delete_channel(channel)
                 .reason(guild_lang.captcha_disable_reason())?
                 .exec()
@@ -79,7 +79,7 @@ impl CaptchaDisable {
 
         // Update the configuration.
         config.captcha = Default::default();
-        state.mongodb().update_guild(&config).await?;
+        state.database.update_guild(&config).await?;
 
         // Send message in logs channel.
         tokio::spawn(async move {
@@ -116,7 +116,7 @@ async fn logs_message(
         .build();
 
     state
-        .http()
+        .http
         .create_message(channel)
         .embeds(&[embed])?
         .exec()

--- a/raidprotect/src/interaction/component/captcha/verify.rs
+++ b/raidprotect/src/interaction/component/captcha/verify.rs
@@ -1,6 +1,6 @@
 //! Captcha verification button and modal.
 
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 use anyhow::Context;
 use raidprotect_captcha::{code::random_human_code, generate_captcha_png};
@@ -48,7 +48,7 @@ impl CaptchaVerifyButton {
     #[instrument(skip(state))]
     pub async fn handle(
         interaction: Interaction,
-        state: Arc<ClusterState>,
+        state: &ClusterState,
     ) -> Result<InteractionResponse, anyhow::Error> {
         let guild = interaction.guild()?;
         let author = interaction.author_id().context("missing author_id")?;
@@ -71,8 +71,9 @@ impl CaptchaVerifyButton {
 
         // Captcha has been regenerated too many times.
         if captcha.regenerate_count >= captcha::MAX_RETRY {
+            let state_clone = state.clone();
             tokio::spawn(kick_after(
-                state,
+                state_clone,
                 guild.id,
                 author,
                 captcha::KICK_AFTER,
@@ -137,7 +138,7 @@ impl CaptchaVerifyButton {
 }
 
 async fn kick_after(
-    state: Arc<ClusterState>,
+    state: ClusterState,
     guild: Id<GuildMarker>,
     user: Id<UserMarker>,
     after: Duration,
@@ -168,7 +169,7 @@ impl CaptchaValidateButton {
     #[instrument(skip(state))]
     pub async fn handle(
         interaction: Interaction,
-        state: Arc<ClusterState>,
+        state: &ClusterState,
     ) -> Result<InteractionResponse, anyhow::Error> {
         let guild = interaction.guild()?;
         let author = interaction.author_id().context("missing author_id")?;

--- a/raidprotect/src/interaction/component/post_in_chat.rs
+++ b/raidprotect/src/interaction/component/post_in_chat.rs
@@ -47,7 +47,7 @@ impl PostInChat {
             author_id,
         };
 
-        state.redis().set(&component).await?;
+        state.cache.set(&component).await?;
 
         // Add ephemeral flag to the response
         response.flags = response
@@ -94,14 +94,14 @@ impl PostInChat {
         let component_id = custom_id
             .id
             .ok_or_else(|| anyhow!("missing component id in custom_id"))?;
-        let mut component = match state.redis().get::<PostInChatButton>(&component_id).await? {
+        let mut component = match state.cache.get::<PostInChatButton>(&component_id).await? {
             Some(component) => component,
             None => return Ok(embed::error::expired_interaction(interaction.locale()?)),
         };
 
         // Get guild language
         let guild = interaction.guild()?;
-        let config = state.mongodb().get_guild_or_create(guild.id).await?;
+        let config = state.database.get_guild_or_create(guild.id).await?;
         let lang = Lang::from(&*config.lang);
 
         // Remove ephemeral flag

--- a/raidprotect/src/interaction/handle.rs
+++ b/raidprotect/src/interaction/handle.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::str::FromStr;
 
 use anyhow::bail;
 use tracing::{debug, error, warn};
@@ -26,16 +26,16 @@ use super::{
 use crate::{cluster::ClusterState, translations::Lang};
 
 /// Handle incoming [`Interaction`].
-pub async fn handle_interaction(interaction: Interaction, state: Arc<ClusterState>) {
+pub async fn handle_interaction(interaction: Interaction, state: &ClusterState) {
     let responder = InteractionResponder::from_interaction(&interaction);
     debug!(id = ?interaction.id, "received {} interaction", interaction.kind.kind());
 
     let lang = interaction.locale().unwrap_or(Lang::DEFAULT);
 
     let response = match interaction.kind {
-        InteractionType::ApplicationCommand => handle_command(interaction, state.clone()).await,
-        InteractionType::MessageComponent => handle_component(interaction, state.clone()).await,
-        InteractionType::ModalSubmit => handle_modal(interaction, state.clone()).await,
+        InteractionType::ApplicationCommand => handle_command(interaction, state).await,
+        InteractionType::MessageComponent => handle_component(interaction, state).await,
+        InteractionType::ModalSubmit => handle_modal(interaction, state).await,
         other => {
             warn!("received unexpected {} interaction", other.kind());
 
@@ -44,12 +44,12 @@ pub async fn handle_interaction(interaction: Interaction, state: Arc<ClusterStat
     };
 
     match response {
-        Ok(response) => responder.respond(&state, response).await,
+        Ok(response) => responder.respond(state, response).await,
         Err(error) => {
             error!(error = ?error, "error while processing interaction");
 
             responder
-                .respond(&state, embed::error::internal_error(lang))
+                .respond(state, embed::error::internal_error(lang))
                 .await;
         }
     }
@@ -58,7 +58,7 @@ pub async fn handle_interaction(interaction: Interaction, state: Arc<ClusterStat
 /// Handle incoming command interaction.
 async fn handle_command(
     interaction: Interaction,
-    state: Arc<ClusterState>,
+    state: &ClusterState,
 ) -> Result<InteractionResponse, anyhow::Error> {
     let name = match &interaction.data {
         Some(InteractionData::ApplicationCommand(data)) => &*data.name,
@@ -66,10 +66,10 @@ async fn handle_command(
     };
 
     match name {
-        "config" => ConfigCommand::handle(interaction, &state).await,
-        "help" => HelpCommand::handle(interaction, &state).await,
-        "kick" => KickCommand::handle(interaction, &state).await,
-        "profile" => ProfileCommand::handle(interaction, &state).await,
+        "config" => ConfigCommand::handle(interaction, state).await,
+        "help" => HelpCommand::handle(interaction, state).await,
+        "kick" => KickCommand::handle(interaction, state).await,
+        "profile" => ProfileCommand::handle(interaction, state).await,
         name => {
             warn!(name = name, "received unknown command");
 
@@ -81,7 +81,7 @@ async fn handle_command(
 /// Handle incoming component interaction
 async fn handle_component(
     interaction: Interaction,
-    state: Arc<ClusterState>,
+    state: &ClusterState,
 ) -> Result<InteractionResponse, anyhow::Error> {
     let custom_id = match &interaction.data {
         Some(InteractionData::MessageComponent(data)) => CustomId::from_str(&*data.custom_id)?,
@@ -93,7 +93,7 @@ async fn handle_component(
         "captcha-enable" => CaptchaEnable::handle(interaction, state).await,
         "captcha-validate" => CaptchaValidateButton::handle(interaction, state).await,
         "captcha-verify" => CaptchaVerifyButton::handle(interaction, state).await,
-        "post-in-chat" => PostInChat::handle(interaction, custom_id, &state).await,
+        "post-in-chat" => PostInChat::handle(interaction, custom_id, state).await,
         name => {
             warn!(name = name, "received unknown component");
 
@@ -105,7 +105,7 @@ async fn handle_component(
 /// Handle incoming modal interaction
 async fn handle_modal(
     interaction: Interaction,
-    _state: Arc<ClusterState>,
+    _state: &ClusterState,
 ) -> Result<InteractionResponse, anyhow::Error> {
     let custom_id = match &interaction.data {
         Some(InteractionData::ModalSubmit(data)) => CustomId::from_str(&*data.custom_id)?,

--- a/raidprotect/src/interaction/handle.rs
+++ b/raidprotect/src/interaction/handle.rs
@@ -131,7 +131,7 @@ pub async fn register_commands(state: &ClusterState, application_id: Id<Applicat
         ProfileCommand::create_command().into(),
     ];
 
-    let client = state.http().interaction(application_id);
+    let client = state.http.interaction(application_id);
 
     if let Err(error) = client.set_global_commands(&commands).exec().await {
         error!(error = ?error, "failed to register commands");

--- a/raidprotect/src/interaction/response.rs
+++ b/raidprotect/src/interaction/response.rs
@@ -42,7 +42,7 @@ impl InteractionResponder {
 
     /// Send a response to an interaction.
     pub async fn respond(&self, state: &ClusterState, response: InteractionResponse) {
-        let client = state.http().interaction(self.application_id);
+        let client = state.http.interaction(self.application_id);
 
         if let Err(error) = client
             .create_response(self.id, &self.token, &response.into_http())


### PR DESCRIPTION
- Remove unneeded `ClusterState` methods that can be replaced with struct fields access
- Remove most `Arc`s since each field is already wrapped with `Arc` 
