### PR TITLE
feat(interaction): add interaction context types

### DIFF
--- a/raidprotect/src/interaction/command/config/mod.rs
+++ b/raidprotect/src/interaction/command/config/mod.rs
@@ -7,11 +7,12 @@ mod captcha;
 
 pub use captcha::CaptchaConfigCommand;
 use twilight_interactions::command::{CommandModel, CreateCommand};
-use twilight_model::{application::interaction::Interaction, guild::Permissions};
+use twilight_model::guild::Permissions;
 
 use crate::{
-    cluster::ClusterState, desc_localizations, impl_command_handle,
-    interaction::response::InteractionResponse,
+    cluster::ClusterState,
+    desc_localizations, impl_guild_command_handle,
+    interaction::{response::InteractionResponse, util::GuildInteractionContext},
 };
 
 /// Configuration command model.
@@ -29,7 +30,7 @@ pub enum ConfigCommand {
     Captcha(CaptchaConfigCommand),
 }
 
-impl_command_handle!(ConfigCommand);
+impl_guild_command_handle!(ConfigCommand);
 desc_localizations!(config_description);
 
 fn config_permissions() -> Permissions {
@@ -39,11 +40,11 @@ fn config_permissions() -> Permissions {
 impl ConfigCommand {
     async fn exec(
         self,
-        interaction: Interaction,
+        ctx: GuildInteractionContext,
         state: &ClusterState,
     ) -> Result<InteractionResponse, anyhow::Error> {
         match self {
-            Self::Captcha(command) => command.exec(interaction, state).await,
+            Self::Captcha(command) => command.exec(ctx, state).await,
         }
     }
 }

--- a/raidprotect/src/interaction/command/help.rs
+++ b/raidprotect/src/interaction/command/help.rs
@@ -4,10 +4,7 @@
 
 use twilight_interactions::command::{CommandModel, CreateCommand};
 use twilight_model::{
-    application::{
-        component::{button::ButtonStyle, ActionRow, Button, Component},
-        interaction::Interaction,
-    },
+    application::component::{button::ButtonStyle, ActionRow, Button, Component},
     channel::message::MessageFlags,
     http::interaction::InteractionResponseType,
 };
@@ -16,7 +13,9 @@ use twilight_util::builder::{embed::EmbedBuilder, InteractionResponseDataBuilder
 use crate::{
     cluster::ClusterState,
     desc_localizations, impl_command_handle,
-    interaction::{embed::COLOR_TRANSPARENT, response::InteractionResponse, util::InteractionExt},
+    interaction::{
+        embed::COLOR_TRANSPARENT, response::InteractionResponse, util::InteractionContext,
+    },
 };
 
 #[derive(Debug, Clone, CommandModel, CreateCommand)]
@@ -34,16 +33,14 @@ desc_localizations!(help_description);
 impl HelpCommand {
     async fn exec(
         self,
-        interaction: Interaction,
+        ctx: InteractionContext,
         _state: &ClusterState,
     ) -> Result<InteractionResponse, anyhow::Error> {
-        let lang = interaction.locale()?;
-
         // Create embed
         let embed = EmbedBuilder::new()
             .color(COLOR_TRANSPARENT)
-            .title(lang.help_embed_title())
-            .description(lang.help_embed_description());
+            .title(ctx.lang.help_embed_title())
+            .description(ctx.lang.help_embed_description());
 
         // Add components (buttons)
         let components = Component::ActionRow(ActionRow {
@@ -52,7 +49,7 @@ impl HelpCommand {
                     custom_id: None,
                     disabled: false,
                     emoji: None,
-                    label: Some(lang.help_support().into()),
+                    label: Some(ctx.lang.help_support().into()),
                     style: ButtonStyle::Link,
                     url: Some("https://raidpro.tk/discord".to_string()),
                 }),
@@ -60,7 +57,7 @@ impl HelpCommand {
                     custom_id: None,
                     disabled: false,
                     emoji: None,
-                    label: Some(lang.help_bot_invite().into()),
+                    label: Some(ctx.lang.help_bot_invite().into()),
                     style: ButtonStyle::Link,
                     url: Some("https://raidpro.tk/invite".to_string()),
                 }),

--- a/raidprotect/src/interaction/handle.rs
+++ b/raidprotect/src/interaction/handle.rs
@@ -30,7 +30,7 @@ pub async fn handle_interaction(interaction: Interaction, state: &ClusterState) 
     let responder = InteractionResponder::from_interaction(&interaction);
     debug!(id = ?interaction.id, "received {} interaction", interaction.kind.kind());
 
-    let lang = interaction.locale().unwrap_or(Lang::DEFAULT);
+    let lang = interaction.lang().unwrap_or(Lang::DEFAULT);
 
     let response = match interaction.kind {
         InteractionType::ApplicationCommand => handle_command(interaction, state).await,
@@ -73,7 +73,7 @@ async fn handle_command(
         name => {
             warn!(name = name, "received unknown command");
 
-            Ok(embed::error::unknown_command(interaction.locale()?))
+            Ok(embed::error::unknown_command(interaction.lang()?))
         }
     }
 }
@@ -97,7 +97,7 @@ async fn handle_component(
         name => {
             warn!(name = name, "received unknown component");
 
-            Ok(embed::error::unknown_command(interaction.locale()?))
+            Ok(embed::error::unknown_command(interaction.lang()?))
         }
     }
 }
@@ -117,7 +117,7 @@ async fn handle_modal(
         name => {
             warn!(name = name, "received unknown modal");
 
-            Ok(embed::error::unknown_command(interaction.locale()?))
+            Ok(embed::error::unknown_command(interaction.lang()?))
         }
     }
 }


### PR DESCRIPTION
Add new `InteractionContext` and `GuildInteractionContext` types to store common fields parsed from interactions.