### PR TITLE
refactor(event): move old command handling

### DIFF
--- a/raidprotect/src/event/message/handle.rs
+++ b/raidprotect/src/event/message/handle.rs
@@ -1,86 +1,35 @@
-use std::collections::HashMap;
-
-use once_cell::sync::Lazy;
 use tracing::{error, info};
 use twilight_model::channel::Message;
-use twilight_util::builder::embed::EmbedBuilder;
 
-use super::parser::parse_message;
-use crate::{cluster::ClusterState, interaction::embed::COLOR_TRANSPARENT, translations::Lang};
-
-/// A mapping between old and new commands
-static OLD_COMMANDS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
-    HashMap::from([
-        ("?kick", "/kick"),
-        ("?ban", "/ban"),
-        ("?clear", "/clear"),
-        ("?raidmode", "/raidmode"),
-        ("?settings", "/config"),
-        ("?captcha", "/config captcha"),
-        ("?userinfo", "/profile"),
-        ("?ui", "/profile"),
-        ("?help", "/help"),
-        ("?invite", "/help"),
-        ("?about", "/help"),
-        ("?stats", "/help"),
-        ("?ping", "/ping"),
-    ])
-});
+use super::{
+    old_command::{is_old_command, warn_old_command},
+    parser::parse_message,
+};
+use crate::cluster::ClusterState;
 
 /// Handle incoming [`Message`].
 ///
 /// This method will forward message to the cache and various auto-moderation
 /// modules.
 pub async fn handle_message(message: Message, state: &ClusterState) {
+    // Ignore messages from bots.
+    if message.author.bot {
+        return;
+    }
+
     let parsed = parse_message(&message);
     state.cache.set(&parsed).await.ok();
 
+    // Warn the user if they're using an old command.
     if is_old_command(&message.content) {
-        let message = message.clone();
-        let state = state.clone();
+        let (message, state) = (message.clone(), state.clone());
 
-        tokio::spawn(warn_old_command(message, state));
+        tokio::spawn(async move {
+            if let Err(error) = warn_old_command(message, &state).await {
+                error!(error = ?error, "failed to warn user about old command");
+            }
+        });
     }
 
     info!("received message: {}", message.content) // Debug util real implementation
-}
-
-async fn warn_old_command(message: Message, state: ClusterState) {
-    let lang = message
-        .author
-        .locale
-        .map(|locale| Lang::from(locale.as_str()))
-        .unwrap_or(Lang::DEFAULT);
-
-    let (old_cmd, new_cmd) = match OLD_COMMANDS
-        .iter()
-        .find(|(old_cmd, _)| message.content.starts_with(**old_cmd))
-    {
-        Some((old_cmd, new_cmd)) => (*old_cmd, *new_cmd),
-        _ => ("", ""),
-    };
-
-    let embed = EmbedBuilder::new()
-        .title(lang.warning_deprecated_command_title())
-        .description(lang.warning_deprecated_command_description(new_cmd, old_cmd))
-        .color(COLOR_TRANSPARENT)
-        .build();
-
-    match state
-        .http
-        .create_message(message.channel_id)
-        .reply(message.id)
-        .embeds(&[embed])
-    {
-        Ok(msg) => {
-            if let Err(error) = msg.exec().await {
-                error!(error = ?error, "failed to send command deprecation warning");
-            }
-        }
-        Err(error) => error!(error = ?error, "failed to create embed"),
-    }
-}
-
-fn is_old_command(content: &str) -> bool {
-    OLD_COMMANDS.keys().any(|cmd| content.starts_with(cmd))
 }

--- a/raidprotect/src/event/message/mod.rs
+++ b/raidprotect/src/event/message/mod.rs
@@ -4,6 +4,7 @@
 //! detection.
 
 mod handle;
+mod old_command;
 
 pub mod parser;
 

--- a/raidprotect/src/event/message/old_command.rs
+++ b/raidprotect/src/event/message/old_command.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use anyhow::bail;
+use once_cell::sync::Lazy;
+use twilight_model::channel::Message;
+use twilight_util::builder::embed::EmbedBuilder;
+
+use crate::{cluster::ClusterState, interaction::embed::COLOR_TRANSPARENT, translations::Lang};
+
+/// Mapping of old command names to new command names.
+static OLD_COMMANDS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
+    HashMap::from([
+        ("?kick", "/kick"),
+        ("?ban", "/ban"),
+        ("?clear", "/clear"),
+        ("?raidmode", "/raidmode"),
+        ("?settings", "/config"),
+        ("?captcha", "/config captcha"),
+        ("?userinfo", "/profile"),
+        ("?ui", "/profile"),
+        ("?help", "/help"),
+        ("?invite", "/help"),
+        ("?about", "/help"),
+        ("?stats", "/help"),
+        ("?ping", "/ping"),
+    ])
+});
+
+/// Check whether a message contains an old command.
+pub fn is_old_command(content: &str) -> bool {
+    if let Some((command, _)) = content.split_once(' ') {
+        return OLD_COMMANDS.contains_key(command);
+    }
+
+    false
+}
+
+/// Send a warning message to the user that they used an old command.
+pub async fn warn_old_command(message: Message, state: &ClusterState) -> Result<(), anyhow::Error> {
+    let lang = message
+        .author
+        .locale
+        .map(|lang| Lang::from(&*lang))
+        .unwrap_or(Lang::DEFAULT);
+
+    if let Some((command, _)) = message.content.split_once(' ') {
+        let new = match OLD_COMMANDS.get(command) {
+            Some(new) => new,
+            None => bail!("no command matching {} found", command),
+        };
+
+        let embed = EmbedBuilder::new()
+            .title(lang.warning_deprecated_command_title())
+            .description(lang.warning_deprecated_command_description(new, command))
+            .color(COLOR_TRANSPARENT)
+            .build();
+
+        state
+            .http
+            .create_message(message.channel_id)
+            .reply(message.id)
+            .embeds(&[embed])?
+            .exec()
+            .await?;
+    }
+
+    Ok(())
+}

--- a/raidprotect/src/event/message/old_command.rs
+++ b/raidprotect/src/event/message/old_command.rs
@@ -10,19 +10,19 @@ use crate::{cluster::ClusterState, interaction::embed::COLOR_TRANSPARENT, transl
 /// Mapping of old command names to new command names.
 static OLD_COMMANDS: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
     HashMap::from([
-        ("?kick", "/kick"),
+        ("?about", "/help"),
         ("?ban", "/ban"),
-        ("?clear", "/clear"),
-        ("?raidmode", "/raidmode"),
-        ("?settings", "/config"),
         ("?captcha", "/config captcha"),
-        ("?userinfo", "/profile"),
-        ("?ui", "/profile"),
+        ("?clear", "/clear"),
         ("?help", "/help"),
         ("?invite", "/help"),
-        ("?about", "/help"),
-        ("?stats", "/help"),
+        ("?kick", "/kick"),
         ("?ping", "/ping"),
+        ("?raidmode", "/raidmode"),
+        ("?settings", "/config"),
+        ("?stats", "/help"),
+        ("?ui", "/profile"),
+        ("?userinfo", "/profile"),
     ])
 });
 


### PR DESCRIPTION
Move the old command handler in it's own module to cleanup `handle.rs`. Some refactoring of the function has been made.